### PR TITLE
D8CORE-1472: Config pages lockup Form helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-config/install
-
 # deal with ignoring or not  bin, vendor, phpstorm files...
 .idea
 .idea/**

--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,7 @@
     },
     "autoload": {
         "psr-4": {
+            "Drupal\\stanford_profile_helper\\": "src/",
             "Drupal\\stanford_paragraph_card\\": "modules/stanford_paragraph_card/src/",
             "Drupal\\stanford_profile_drush\\": "modules/stanford_profile_drush/src/",
             "Drupal\\stanford_profile_styles\\": "modules/stanford_profile_styles/src/"

--- a/src/Config/ConfigOverrides.php
+++ b/src/Config/ConfigOverrides.php
@@ -163,7 +163,7 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
         'line2' => $config_page->get('su_line_2')->getString(),
         'line3' => $config_page->get('su_line_3')->getString(),
         'line4' => $config_page->get('su_line_4')->getString(),
-        'line5' => $config_page->get('su_line_1')->getString(),
+        'line5' => $config_page->get('su_line_5')->getString(),
       ],
       'logo' => [
         'use_default' => ($config_page->get('su_use_theme_logo')->getString() == "1") ? TRUE : FALSE,

--- a/src/Config/ConfigOverrides.php
+++ b/src/Config/ConfigOverrides.php
@@ -70,10 +70,10 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
    */
   public function __construct(
     StateInterface $state,
-    ConfigPagesLoaderServiceInterface $config_pages_loader = NULL,
-    ConfigFactoryInterface $config_factory = NULL,
-    EntityTypeManagerInterface $entity_type_manager = NULL,
-    StreamWrapperManagerInterface $stream_wrapper_manager = NULL
+    ConfigPagesLoaderServiceInterface $config_pages_loader,
+    ConfigFactoryInterface $config_factory,
+    EntityTypeManagerInterface $entity_type_manager,
+    StreamWrapperManagerInterface $stream_wrapper_manager
   ) {
     $this->state = $state;
     $this->configPagesLoader = $config_pages_loader;

--- a/src/Config/ConfigOverrides.php
+++ b/src/Config/ConfigOverrides.php
@@ -76,22 +76,10 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
     StreamWrapperManagerInterface $stream_wrapper_manager = NULL
   ) {
     $this->state = $state;
-
-    if ($config_pages_loader) {
-      $this->configPagesLoader = $config_pages_loader;
-    }
-
-    if ($config_factory) {
-      $this->configFactory = $config_factory;
-    }
-
-    if ($entity_type_manager) {
-      $this->entityTypeManager = $entity_type_manager;
-    }
-
-    if ($stream_wrapper_manager) {
-      $this->streamWrapperManager = $stream_wrapper_manager;
-    }
+    $this->configPagesLoader = $config_pages_loader;
+    $this->configFactory = $config_factory;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->streamWrapperManager = $stream_wrapper_manager;
   }
 
   /**

--- a/src/Config/ConfigOverrides.php
+++ b/src/Config/ConfigOverrides.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\stanford_profile\Config;
+namespace Drupal\stanford_profile_helper\Config;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -15,7 +15,7 @@ use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
 /**
  * Config overrides for stanford profile.
  *
- * @package Drupal\stanford_profile\Config
+ * @package Drupal\stanford_profile_helper\Config
  */
 class ConfigOverrides implements ConfigFactoryOverrideInterface {
 
@@ -166,8 +166,8 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
         'line5' => $config_page->get('su_line_1')->getString(),
       ],
       'logo' => [
-        'use_default' => ($config_page->get('su_use_theme_logo')->getString() == "1") ? TRUE : FALSE
-      ]
+        'use_default' => ($config_page->get('su_use_theme_logo')->getString() == "1") ? TRUE : FALSE,
+      ],
     ];
   }
 

--- a/src/Config/ConfigOverrides.php
+++ b/src/Config/ConfigOverrides.php
@@ -201,37 +201,6 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
   }
 
   /**
-   * Disable google tag manager entities when not on prod environment.
-   *
-   * @param array $names
-   *   Config names.
-   * @param array $overrides
-   *   Keyed array of config overrides.
-   */
-  protected function setOverridesGoogleTag(array $names, array &$overrides) {
-    if ($this->isProdEnv()) {
-      return;
-    }
-
-    foreach ($names as $name) {
-      if (strpos($name, 'google_tag.container.') === 0) {
-        $overrides[$name]['status'] = FALSE;
-      }
-    }
-  }
-
-  /**
-   * Check if this is Acquia's prod environment.
-   *
-   * @return bool
-   *   Is Acquia environment.
-   */
-  protected function isProdEnv() {
-    $ah_env = $_ENV['AH_SITE_ENVIRONMENT'] ?? NULL;
-    return $ah_env == 'prod' || preg_match('/^\d*live$/', $ah_env);
-  }
-
-  /**
    * {@inheritDoc}
    */
   public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
@@ -242,7 +211,7 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
    * {@inheritDoc}
    */
   public function getCacheSuffix() {
-    return 'StanfordProfileConfigOverride';
+    return 'StanfordProfileHelperConfigOverride';
   }
 
   /**

--- a/src/Config/ConfigOverrides.php
+++ b/src/Config/ConfigOverrides.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Drupal\stanford_profile\Config;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\config_pages\ConfigPagesLoaderServiceInterface;
+use Drupal\config_pages\ConfigPagesInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+
+/**
+ * Config overrides for stanford profile.
+ *
+ * @package Drupal\stanford_profile\Config
+ */
+class ConfigOverrides implements ConfigFactoryOverrideInterface {
+
+  /**
+   * State service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * Config pages loader service.
+   *
+   * @var \Drupal\config_pages\ConfigPagesLoaderServiceInterface
+   */
+  protected $configPagesLoader;
+
+  /**
+   * Config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Config Entity Type Manager Interface.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * StreamWrapperInterface service.
+   *
+   * @var \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface
+   */
+  protected $streamWrapperManager;
+
+  /**
+   * ConfigOverrides constructor.
+   *
+   * @param \Drupal\Core\State\StateInterface $state
+   *   State service.
+   * @param \Drupal\config_pages\ConfigPagesLoaderServiceInterface|null $config_pages_loader
+   *   Config pages service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface|null $config_factory
+   *   Config factory service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface|null $entity_type_manager
+   *   Entity type manager interface.
+   * @param \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface|null $stream_wrapper_manager
+   *   Stream wrapper manager interface.
+   */
+  public function __construct(
+    StateInterface $state,
+    ConfigPagesLoaderServiceInterface $config_pages_loader = NULL,
+    ConfigFactoryInterface $config_factory = NULL,
+    EntityTypeManagerInterface $entity_type_manager = NULL,
+    StreamWrapperManagerInterface $stream_wrapper_manager = NULL
+  ) {
+    $this->state = $state;
+
+    if ($config_pages_loader) {
+      $this->configPagesLoader = $config_pages_loader;
+    }
+
+    if ($config_factory) {
+      $this->configFactory = $config_factory;
+    }
+
+    if ($entity_type_manager) {
+      $this->entityTypeManager = $entity_type_manager;
+    }
+
+    if ($stream_wrapper_manager) {
+      $this->streamWrapperManager = $stream_wrapper_manager;
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+
+    // Theme settings override.
+    $this->setLockupOverrides($names, $overrides);
+
+    // Overrides.
+    return $overrides;
+  }
+
+  /**
+   * Disable google tag manager entities when not on prod environment.
+   *
+   * @param array $names
+   *   Config names.
+   * @param array $overrides
+   *   Keyed array of config overrides.
+   */
+  protected function setLockupOverrides(array $names, array &$overrides) {
+
+    // Avoid circular loops.
+    if (!$this->configFactory || in_array('system.theme', $names)) {
+      return;
+    }
+
+    // Validate we are working with the info we need.
+    $theme_info = $this->configFactory->get('system.theme');
+    if (!$this->configPagesLoader || !$theme_info || !in_array($theme_info->get('default') . '.settings', $names)) {
+      return;
+    }
+
+    // Get the default theme from the config.
+    $theme_name = $theme_info->get('default');
+    $config_page = $this->configPagesLoader->load('lockup_settings');
+
+    // Failed to load the config page or not enabled.
+    if (!$config_page || $config_page->get('su_lockup_enabled')->getString() == "1") {
+      return;
+    }
+
+    // Do the overrides.
+    $this->setLockupTextOverrides($overrides, $theme_name, $config_page);
+
+    // Get and set a file path that is relative to the site base dir.
+    $this->setLockupFileOverrides($overrides, $theme_name, $config_page);
+
+  }
+
+  /**
+   * Set the lockup text overrides.
+   *
+   * @param array $overrides
+   *   The array of overrides.
+   * @param string $theme_name
+   *   The name of the default theme.
+   * @param \Drupal\config_pages\ConfigPagesInterface $config_page
+   *   A config page object.
+   */
+  protected function setLockupTextOverrides(array &$overrides, $theme_name, ConfigPagesInterface $config_page) {
+    $overrides[$theme_name . '.settings'] = [
+      'lockup' => [
+        'option' => $config_page->get('su_lockup_options')->getString(),
+        'line1' => $config_page->get('su_line_1')->getString(),
+        'line2' => $config_page->get('su_line_2')->getString(),
+        'line3' => $config_page->get('su_line_3')->getString(),
+        'line4' => $config_page->get('su_line_4')->getString(),
+        'line5' => $config_page->get('su_line_1')->getString(),
+      ],
+      'logo' => [
+        'use_default' => ($config_page->get('su_use_theme_logo')->getString() == "1") ? TRUE : FALSE
+      ]
+    ];
+  }
+
+  /**
+   * Set the lockup file/logo overrides.
+   *
+   * @param array $overrides
+   *   The array of overrides.
+   * @param string $theme_name
+   *   The name of the default theme.
+   * @param \Drupal\config_pages\ConfigPagesInterface $config_page
+   *   A config page object.
+   */
+  protected function setLockupFileOverrides(array &$overrides, $theme_name, ConfigPagesInterface $config_page) {
+
+    $file_field = $config_page->get('su_upload_logo_image')->getValue();
+    if (empty($file_field[0]['target_id'])) {
+      return;
+    }
+
+    $file = $this->entityTypeManager->getStorage('file')->load($file_field[0]['target_id']);
+    if (!$file) {
+      return;
+    }
+
+    $file_uri = $file->getFileUri();
+    $wrapper = $this->streamWrapperManager->getViaUri($file_uri);
+    $file_path = $wrapper->getExternalUrl();
+
+    $overrides[$theme_name . '.settings']['logo']['path'] = $file_path;
+  }
+
+  /**
+   * Disable google tag manager entities when not on prod environment.
+   *
+   * @param array $names
+   *   Config names.
+   * @param array $overrides
+   *   Keyed array of config overrides.
+   */
+  protected function setOverridesGoogleTag(array $names, array &$overrides) {
+    if ($this->isProdEnv()) {
+      return;
+    }
+
+    foreach ($names as $name) {
+      if (strpos($name, 'google_tag.container.') === 0) {
+        $overrides[$name]['status'] = FALSE;
+      }
+    }
+  }
+
+  /**
+   * Check if this is Acquia's prod environment.
+   *
+   * @return bool
+   *   Is Acquia environment.
+   */
+  protected function isProdEnv() {
+    $ah_env = $_ENV['AH_SITE_ENVIRONMENT'] ?? NULL;
+    return $ah_env == 'prod' || preg_match('/^\d*live$/', $ah_env);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCacheSuffix() {
+    return 'StanfordProfileConfigOverride';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+}

--- a/src/Config/ConfigOverrides.php
+++ b/src/Config/ConfigOverrides.php
@@ -59,13 +59,13 @@ class ConfigOverrides implements ConfigFactoryOverrideInterface {
    *
    * @param \Drupal\Core\State\StateInterface $state
    *   State service.
-   * @param \Drupal\config_pages\ConfigPagesLoaderServiceInterface|null $config_pages_loader
+   * @param \Drupal\config_pages\ConfigPagesLoaderServiceInterface $config_pages_loader
    *   Config pages service.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface|null $config_factory
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   Config factory service.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface|null $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager interface.
-   * @param \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface|null $stream_wrapper_manager
+   * @param \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface $stream_wrapper_manager
    *   Stream wrapper manager interface.
    */
   public function __construct(

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -271,6 +271,9 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   $decanter = Link::fromTextAndUrl(t('Decanter Lockup Component'), Url::fromUri('https://decanter.stanford.edu/component/identity-lockup/'))->toString();
   $form['group_lockup_options']['#field_prefix'] = "<p>$img</p><p>More examples can be found at: $decanter</p>";
 
+  // Change the label for none/disabled
+  $form['su_lockup_options']['widget']['#options']['_none'] = t('Default: Lines 1');
+
   $form['su_upload_logo_image']['#states'] = [
     'invisible' => [
       ':input[name="su_use_theme_logo[value]"]' => ['checked' => TRUE],
@@ -280,93 +283,69 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
     ],
   ];
 
+  // LINE 1.
   $form['su_line_1']['widget']['0']['value']['#states'] = [
-    'invisible' => [
-      [':input[name="su_lockup_options"]' => ['value' => 'none']],
-      [':input[name="su_lockup_options"]' => ['value' => 'o']],
-      [':input[name="su_lockup_options"]' => ['value' => 'r']],
-    ],
+    'invisible' => _stanford_profile_helper_get_lockup_states(
+      ['none', 'o', 'r'],
+      ':input[name="su_lockup_options"]'
+    ),
   ];
 
+  // LINE 2.
   $form['su_line_2']['widget']['0']['value']['#states'] = [
-    'invisible' => [
-      [':input[name="su_lockup_options"]' => ['value' => 'none']],
-      [':input[name="su_lockup_options"]' => ['value' => 'a']],
-      [':input[name="su_lockup_options"]' => ['value' => 'd']],
-      [':input[name="su_lockup_options"]' => ['value' => 'h']],
-      [':input[name="su_lockup_options"]' => ['value' => 'i']],
-      [':input[name="su_lockup_options"]' => ['value' => 'k']],
-      [':input[name="su_lockup_options"]' => ['value' => 'l']],
-      [':input[name="su_lockup_options"]' => ['value' => 'n']],
-      [':input[name="su_lockup_options"]' => ['value' => 'o']],
-      [':input[name="su_lockup_options"]' => ['value' => 'p']],
-      [':input[name="su_lockup_options"]' => ['value' => 'q']],
-      [':input[name="su_lockup_options"]' => ['value' => 'r']],
-    ],
+    'invisible' => _stanford_profile_helper_get_lockup_states(
+      ['none', 'a', 'd', 'h', 'i', 'k', 'l', 'n', 'o', 'p', 'q', 'r'],
+      ':input[name="su_lockup_options"]'
+    ),
   ];
 
+  // LINE 3.
   $form['su_line_3']['widget']['0']['value']['#states'] = [
-    'invisible' => [
-      [':input[name="su_lockup_options"]' => ['value' => 'none']],
-      [':input[name="su_lockup_options"]' => ['value' => 'a']],
-      [':input[name="su_lockup_options"]' => ['value' => 'b']],
-      [':input[name="su_lockup_options"]' => ['value' => 'c']],
-      [':input[name="su_lockup_options"]' => ['value' => 'f']],
-      [':input[name="su_lockup_options"]' => ['value' => 'g']],
-      [':input[name="su_lockup_options"]' => ['value' => 'j']],
-      [':input[name="su_lockup_options"]' => ['value' => 'k']],
-      [':input[name="su_lockup_options"]' => ['value' => 'l']],
-      [':input[name="su_lockup_options"]' => ['value' => 'm']],
-      [':input[name="su_lockup_options"]' => ['value' => 'n']],
-      [':input[name="su_lockup_options"]' => ['value' => 'o']],
-      [':input[name="su_lockup_options"]' => ['value' => 'p']],
-      [':input[name="su_lockup_options"]' => ['value' => 'q']],
-      [':input[name="su_lockup_options"]' => ['value' => 'r']],
-      [':input[name="su_lockup_options"]' => ['value' => 's']],
-    ],
+    'invisible' => _stanford_profile_helper_get_lockup_states(
+      ['none', 'a', 'b', 'c', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's'],
+      ':input[name="su_lockup_options"]'
+    ),
   ];
 
+  // LINE 4.
   $form['su_line_4']['widget']['0']['value']['#states'] = [
-    'invisible' => [
-      [':input[name="su_lockup_options"]' => ['value' => 'none']],
-      [':input[name="su_lockup_options"]' => ['value' => 'a']],
-      [':input[name="su_lockup_options"]' => ['value' => 'b']],
-      [':input[name="su_lockup_options"]' => ['value' => 'c']],
-      [':input[name="su_lockup_options"]' => ['value' => 'd']],
-      [':input[name="su_lockup_options"]' => ['value' => 'e']],
-      [':input[name="su_lockup_options"]' => ['value' => 'f']],
-      [':input[name="su_lockup_options"]' => ['value' => 'g']],
-      [':input[name="su_lockup_options"]' => ['value' => 'j']],
-      [':input[name="su_lockup_options"]' => ['value' => 'k']],
-      [':input[name="su_lockup_options"]' => ['value' => 'l']],
-      [':input[name="su_lockup_options"]' => ['value' => 'm']],
-      [':input[name="su_lockup_options"]' => ['value' => 'n']],
-      [':input[name="su_lockup_options"]' => ['value' => 'r']],
-    ],
+    'invisible' => _stanford_profile_helper_get_lockup_states(
+      ['none', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'r'],
+      ':input[name="su_lockup_options"]'
+    ),
   ];
 
+  // LINE 5.
   $form['su_line_5']['widget']['0']['value']['#states'] = [
-    'invisible' => [
-      [':input[name="su_lockup_options"]' => ['value' => 'none']],
-      [':input[name="su_lockup_options"]' => ['value' => 'b']],
-      [':input[name="su_lockup_options"]' => ['value' => 'd']],
-      [':input[name="su_lockup_options"]' => ['value' => 'e']],
-      [':input[name="su_lockup_options"]' => ['value' => 'f']],
-      [':input[name="su_lockup_options"]' => ['value' => 'h']],
-      [':input[name="su_lockup_options"]' => ['value' => 'i']],
-      [':input[name="su_lockup_options"]' => ['value' => 'l']],
-      [':input[name="su_lockup_options"]' => ['value' => 'm']],
-      [':input[name="su_lockup_options"]' => ['value' => 'n']],
-      [':input[name="su_lockup_options"]' => ['value' => 'o']],
-      [':input[name="su_lockup_options"]' => ['value' => 'p']],
-      [':input[name="su_lockup_options"]' => ['value' => 'q']],
-      [':input[name="su_lockup_options"]' => ['value' => 's']],
-      [':input[name="su_lockup_options"]' => ['value' => 't']],
-    ],
+    'invisible' => _stanford_profile_helper_get_lockup_states(
+      ['none', 'b', 'd', 'e', 'f', 'h', 'i', 'l', 'm', 'n', 'o', 'p', 'q', 's', 't'],
+      ':input[name="su_lockup_options"]'
+    ),
   ];
 
   // Clear caches on submit.
   $form['actions']["submit"]['#submit'][] = "stanford_profile_helper_form_config_pages_lockup_settings_form_alter_submit";
+}
+
+/**
+ * Creates a states array.
+ *
+ * @param  array  $opts
+ *   Allowed values.
+ * @param  string $input
+ *   Field selector
+ *
+ * @return array
+ *   State array.
+ */
+function _stanford_profile_helper_get_lockup_states(array $opts, $input) {
+  $ret = [];
+  foreach ($opts as $val) {
+    $ret[] = [
+      $input => ['value' => $val],
+    ];
+  }
+  return $ret;
 }
 
 /**

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -16,7 +16,8 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
-
+use Drupal\Core\Url;
+use Drupal\Core\Link;
 /**
  * Implements hook_form_alter().
  */

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -337,14 +337,14 @@ function stanford_profile_helper_field_group_form_process_build_alter(&$element)
     $element['group_lockup_options']['#states'] = [
       'visible' => [
         ':input[name="su_lockup_enabled[value]"]' => [
-          'checked' => false,
+          'checked' => FALSE,
         ],
       ],
     ];
     $element['group_logo_image']['#states'] = [
       'visible' => [
         ':input[name="su_lockup_enabled[value]"]' => [
-          'checked' => false,
+          'checked' => FALSE,
         ],
       ],
     ];
@@ -354,7 +354,7 @@ function stanford_profile_helper_field_group_form_process_build_alter(&$element)
 /**
  * Creates a states array.
  *
- * @param array  $opts
+ * @param array $opts
  *   Allowed values.
  * @param string $input
  *   Field selector.

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -297,7 +297,7 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   // LINE 2.
   $form['su_line_2']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      ['none', 'a', 'd', 'h', 'i', 'k', 'l', 'n', 'o', 'p', 'q', 'r'],
+      ['_none', 'none', 'a', 'd', 'h', 'i', 'k', 'l', 'n', 'o', 'p', 'q', 'r'],
       ':input[name="su_lockup_options"]'
     ),
   ];
@@ -305,7 +305,7 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   // LINE 3.
   $form['su_line_3']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      ['none', 'a', 'b', 'c', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's'],
+      ['_none', 'none', 'a', 'b', 'c', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's'],
       ':input[name="su_lockup_options"]'
     ),
   ];
@@ -313,7 +313,7 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   // LINE 4.
   $form['su_line_4']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      ['none', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'r'],
+      ['_none', 'none', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'r'],
       ':input[name="su_lockup_options"]'
     ),
   ];
@@ -321,7 +321,7 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   // LINE 5.
   $form['su_line_5']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      ['none', 'b', 'd', 'e', 'f', 'h', 'i', 'l', 'm', 'n', 'o', 'p', 'q', 's', 't'],
+      ['_none', 'none', 'b', 'd', 'e', 'f', 'h', 'i', 'l', 'm', 'n', 'o', 'p', 'q', 's', 't'],
       ':input[name="su_lockup_options"]'
     ),
   ];

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -274,7 +274,7 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   $decanter = Link::fromTextAndUrl(t('Decanter Lockup Component'), Url::fromUri('https://decanter.stanford.edu/component/identity-lockup/'))->toString();
   $form['group_lockup_options']['#field_prefix'] = "<p>$img</p><p>More examples can be found at: $decanter</p>";
 
-  // Change the label for none/disabled
+  // Change the label for none/disabled.
   $form['su_upload_logo_image']['#states'] = [
     'invisible' => [
       ':input[name="su_use_theme_logo[value]"]' => ['checked' => TRUE],
@@ -337,16 +337,16 @@ function stanford_profile_helper_field_group_form_process_build_alter(&$element)
     $element['group_lockup_options']['#states'] = [
       'visible' => [
         ':input[name="su_lockup_enabled[value]"]' => [
-          'checked' => false
-        ]
-      ]
+          'checked' => false,
+        ],
+      ],
     ];
     $element['group_logo_image']['#states'] = [
       'visible' => [
         ':input[name="su_lockup_enabled[value]"]' => [
-          'checked' => false
-        ]
-      ]
+          'checked' => false,
+        ],
+      ],
     ];
   }
 }
@@ -354,10 +354,10 @@ function stanford_profile_helper_field_group_form_process_build_alter(&$element)
 /**
  * Creates a states array.
  *
- * @param  array  $opts
+ * @param array  $opts
  *   Allowed values.
- * @param  string $input
- *   Field selector
+ * @param string $input
+ *   Field selector.
  *
  * @return array
  *   State array.

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -289,7 +289,7 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   // LINE 1.
   $form['su_line_1']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      ['none', 'o', 'r'],
+      ['_none', 'none', 'o', 'r'],
       ':input[name="su_lockup_options"]'
     ),
   ];

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -381,8 +381,5 @@ function _stanford_profile_helper_get_lockup_states(array $opts, $input) {
  *   The form state.
  */
 function stanford_profile_helper_form_config_pages_lockup_settings_form_alter_submit(array &$form, FormStateInterface $form_state) {
-  \Drupal::service('cache.render')
-    ->invalidateAll();
-  \Drupal::service('cache_tags.invalidator')
-    ->invalidateTags();
+  drupal_flush_all_caches();
 }

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -260,3 +260,121 @@ function stanford_profile_helper_config_readonly_whitelist_patterns() {
   // Allow the theme settings to be changed in the UI.
   return ["$default_theme.settings"];
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(array &$form, FormStateInterface $form_state) {
+
+  $img = '<img src="' . base_path() . drupal_get_path('theme', 'stanford_basic') . '/dist/assets/img/lockup-example.png" />';
+  $decanter = Link::fromTextAndUrl(t('Decanter Lockup Component'), Url::fromUri('https://decanter.stanford.edu/component/identity-lockup/'))->toString();
+  $form['group_lockup_options']['#field_prefix'] = "<p>$img</p><p>More examples can be found at: $decanter</p>";
+
+  $form['su_upload_logo_image']['#states'] = [
+    'invisible' => [
+      ':input[name="su_use_theme_logo[value]"]' => ['checked' => TRUE],
+    ],
+    'visible' => [
+      ':input[name="su_use_theme_logo[value]"]' => ['checked' => FALSE],
+    ],
+  ];
+
+  $form['su_line_1']['widget']['0']['value']['#states'] = [
+    'invisible' => [
+      [':input[name="su_lockup_options"]' => ['value' => 'none']],
+      [':input[name="su_lockup_options"]' => ['value' => 'o']],
+      [':input[name="su_lockup_options"]' => ['value' => 'r']],
+    ],
+  ];
+
+  $form['su_line_2']['widget']['0']['value']['#states'] = [
+    'invisible' => [
+      [':input[name="su_lockup_options"]' => ['value' => 'none']],
+      [':input[name="su_lockup_options"]' => ['value' => 'a']],
+      [':input[name="su_lockup_options"]' => ['value' => 'd']],
+      [':input[name="su_lockup_options"]' => ['value' => 'h']],
+      [':input[name="su_lockup_options"]' => ['value' => 'i']],
+      [':input[name="su_lockup_options"]' => ['value' => 'k']],
+      [':input[name="su_lockup_options"]' => ['value' => 'l']],
+      [':input[name="su_lockup_options"]' => ['value' => 'n']],
+      [':input[name="su_lockup_options"]' => ['value' => 'o']],
+      [':input[name="su_lockup_options"]' => ['value' => 'p']],
+      [':input[name="su_lockup_options"]' => ['value' => 'q']],
+      [':input[name="su_lockup_options"]' => ['value' => 'r']],
+    ],
+  ];
+
+  $form['su_line_3']['widget']['0']['value']['#states'] = [
+    'invisible' => [
+      [':input[name="su_lockup_options"]' => ['value' => 'none']],
+      [':input[name="su_lockup_options"]' => ['value' => 'a']],
+      [':input[name="su_lockup_options"]' => ['value' => 'b']],
+      [':input[name="su_lockup_options"]' => ['value' => 'c']],
+      [':input[name="su_lockup_options"]' => ['value' => 'f']],
+      [':input[name="su_lockup_options"]' => ['value' => 'g']],
+      [':input[name="su_lockup_options"]' => ['value' => 'j']],
+      [':input[name="su_lockup_options"]' => ['value' => 'k']],
+      [':input[name="su_lockup_options"]' => ['value' => 'l']],
+      [':input[name="su_lockup_options"]' => ['value' => 'm']],
+      [':input[name="su_lockup_options"]' => ['value' => 'n']],
+      [':input[name="su_lockup_options"]' => ['value' => 'o']],
+      [':input[name="su_lockup_options"]' => ['value' => 'p']],
+      [':input[name="su_lockup_options"]' => ['value' => 'q']],
+      [':input[name="su_lockup_options"]' => ['value' => 'r']],
+      [':input[name="su_lockup_options"]' => ['value' => 's']],
+    ],
+  ];
+
+  $form['su_line_4']['widget']['0']['value']['#states'] = [
+    'invisible' => [
+      [':input[name="su_lockup_options"]' => ['value' => 'none']],
+      [':input[name="su_lockup_options"]' => ['value' => 'a']],
+      [':input[name="su_lockup_options"]' => ['value' => 'b']],
+      [':input[name="su_lockup_options"]' => ['value' => 'c']],
+      [':input[name="su_lockup_options"]' => ['value' => 'd']],
+      [':input[name="su_lockup_options"]' => ['value' => 'e']],
+      [':input[name="su_lockup_options"]' => ['value' => 'f']],
+      [':input[name="su_lockup_options"]' => ['value' => 'g']],
+      [':input[name="su_lockup_options"]' => ['value' => 'j']],
+      [':input[name="su_lockup_options"]' => ['value' => 'k']],
+      [':input[name="su_lockup_options"]' => ['value' => 'l']],
+      [':input[name="su_lockup_options"]' => ['value' => 'm']],
+      [':input[name="su_lockup_options"]' => ['value' => 'n']],
+      [':input[name="su_lockup_options"]' => ['value' => 'r']],
+    ],
+  ];
+
+  $form['su_line_5']['widget']['0']['value']['#states'] = [
+    'invisible' => [
+      [':input[name="su_lockup_options"]' => ['value' => 'none']],
+      [':input[name="su_lockup_options"]' => ['value' => 'b']],
+      [':input[name="su_lockup_options"]' => ['value' => 'd']],
+      [':input[name="su_lockup_options"]' => ['value' => 'e']],
+      [':input[name="su_lockup_options"]' => ['value' => 'f']],
+      [':input[name="su_lockup_options"]' => ['value' => 'h']],
+      [':input[name="su_lockup_options"]' => ['value' => 'i']],
+      [':input[name="su_lockup_options"]' => ['value' => 'l']],
+      [':input[name="su_lockup_options"]' => ['value' => 'm']],
+      [':input[name="su_lockup_options"]' => ['value' => 'n']],
+      [':input[name="su_lockup_options"]' => ['value' => 'o']],
+      [':input[name="su_lockup_options"]' => ['value' => 'p']],
+      [':input[name="su_lockup_options"]' => ['value' => 'q']],
+      [':input[name="su_lockup_options"]' => ['value' => 's']],
+      [':input[name="su_lockup_options"]' => ['value' => 't']],
+    ],
+  ];
+
+  // Clear caches on submit.
+  $form['actions']["submit"]['#submit'][] = "stanford_profile_helper_form_config_pages_lockup_settings_form_alter_submit";
+}
+
+/**
+ * Clear cache after lockup config page form submit.
+ *
+ * @param  array              $form       The form array.
+ * @param  FormStateInterface $form_state The form state.
+ */
+function stanford_profile_helper_form_config_pages_lockup_settings_form_alter_submit(array &$form, FormStateInterface $form_state) {
+  $renderCache = \Drupal::service('cache.render');
+  $renderCache->invalidateAll();
+}

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -381,5 +381,5 @@ function _stanford_profile_helper_get_lockup_states(array $opts, $input) {
  *   The form state.
  */
 function stanford_profile_helper_form_config_pages_lockup_settings_form_alter_submit(array &$form, FormStateInterface $form_state) {
-  drupal_flush_all_caches();
+  Cache::invalidateTags(['config:system.site']);
 }

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -373,7 +373,7 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
  *
  * @param array $form
  *   The form array.
- * @param FormStateInterface $form_state
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state.
  */
 function stanford_profile_helper_form_config_pages_lockup_settings_form_alter_submit(array &$form, FormStateInterface $form_state) {

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -18,7 +18,6 @@ use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Link;
-use Drupal\Core\Cache\Cache;
 
 /**
  * Implements hook_form_alter().

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -270,9 +270,19 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
 
   // This alter function adds an image above the settings and provides
   // the visibility states for the line input field elements.
-  $img = '<img src="' . base_path() . drupal_get_path('theme', 'stanford_basic') . '/dist/assets/img/lockup-example.png" />';
-  $decanter = Link::fromTextAndUrl(t('Decanter Lockup Component'), Url::fromUri('https://decanter.stanford.edu/component/identity-lockup/'))->toString();
-  $form['group_lockup_options']['#field_prefix'] = "<p>$img</p><p>More examples can be found at: $decanter</p>";
+  $form['group_lockup_options']['intro'] = [
+    'image' => [
+      '#theme' => 'image',
+      '#uri' => drupal_get_path('theme', 'stanford_basic') . '/dist/assets/img/lockup-example.png',
+    ],
+    'text' => [
+      '#type' => 'link',
+      '#url' => Url::fromUri('https://decanter.stanford.edu/component/identity-lockup/'),
+      '#title' => t('Decanter Lockup Component'),
+      '#prefix' => '<p>',
+      '#suffix' => '</p>',
+    ],
+  ];
 
   // Change the label for none/disabled.
   $form['su_upload_logo_image']['#states'] = [

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -18,6 +18,7 @@ use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Link;
+use Drupal\Core\Cache\Cache;
 
 /**
  * Implements hook_form_alter().
@@ -275,8 +276,6 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   $form['group_lockup_options']['#field_prefix'] = "<p>$img</p><p>More examples can be found at: $decanter</p>";
 
   // Change the label for none/disabled
-  $form['su_lockup_options']['widget']['#options']['_none'] = t('Default: Lines 1');
-
   $form['su_upload_logo_image']['#states'] = [
     'invisible' => [
       ':input[name="su_use_theme_logo[value]"]' => ['checked' => TRUE],
@@ -331,6 +330,29 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
 }
 
 /**
+ * Implements field_group_form_process_build_alter().
+ */
+function stanford_profile_helper_field_group_form_process_build_alter(&$element) {
+  // Hide / Show the field groups based on the enabled checkbox.
+  if (isset($element['group_lockup_options'])) {
+    $element['group_lockup_options']['#states'] = [
+      'visible' => [
+        ':input[name="su_lockup_enabled[value]"]' => [
+          'checked' => false
+        ]
+      ]
+    ];
+    $element['group_logo_image']['#states'] = [
+      'visible' => [
+        ':input[name="su_lockup_enabled[value]"]' => [
+          'checked' => false
+        ]
+      ]
+    ];
+  }
+}
+
+/**
  * Creates a states array.
  *
  * @param  array  $opts
@@ -360,6 +382,8 @@ function _stanford_profile_helper_get_lockup_states(array $opts, $input) {
  *   The form state.
  */
 function stanford_profile_helper_form_config_pages_lockup_settings_form_alter_submit(array &$form, FormStateInterface $form_state) {
-  $renderCache = \Drupal::service('cache.render');
-  $renderCache->invalidateAll();
+  \Drupal::service('cache.render')
+    ->invalidateAll();
+  \Drupal::service('cache_tags.invalidator')
+    ->invalidateTags();
 }

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -371,8 +371,10 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
 /**
  * Clear cache after lockup config page form submit.
  *
- * @param  array              $form       The form array.
- * @param  FormStateInterface $form_state The form state.
+ * @param array $form
+ *   The form array.
+ * @param FormStateInterface $form_state
+ *   The form state.
  */
 function stanford_profile_helper_form_config_pages_lockup_settings_form_alter_submit(array &$form, FormStateInterface $form_state) {
   $renderCache = \Drupal::service('cache.render');

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -17,7 +17,6 @@ use Drupal\Core\Site\Settings;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Url;
-use Drupal\Core\Link;
 
 /**
  * Implements hook_form_alter().

--- a/stanford_profile_helper.services.yml
+++ b/stanford_profile_helper.services.yml
@@ -1,0 +1,6 @@
+services:
+  stanford_profile_helper.config_overrider:
+    class: Drupal\stanford_profile_helper\Config\ConfigOverrides
+    arguments: ['@state', '@config_pages.loader', '@config.factory', '@entity_type.manager', '@stream_wrapper_manager']
+    tags:
+      - {name: config.factory.override, priority: 5}

--- a/tests/src/Unit/Config/ConfigOverridesTest.php
+++ b/tests/src/Unit/Config/ConfigOverridesTest.php
@@ -238,7 +238,7 @@ class ConfigOverridesTest extends UnitTestCase {
     $this->assertNull($this->overrideService->createConfigObject('name'));
     $this->assertEquals($this->overrideService->getCacheSuffix(), 'StanfordProfileConfigOverride');
     $obj = new CacheableMetadata();
-    $this->assertEquals(get_class($obj), get_class($this->overrideService->getCacheableMetadata('name'));
+    $this->assertEquals(get_class($obj), get_class($this->overrideService->getCacheableMetadata('name')));
   }
 
 }

--- a/tests/src/Unit/Config/ConfigOverridesTest.php
+++ b/tests/src/Unit/Config/ConfigOverridesTest.php
@@ -105,7 +105,6 @@ class ConfigOverridesTest extends UnitTestCase {
           'line4' => 'Line 4',
           'line5' => 'Line 5',
         ],
-        'use_logo' => TRUE,
         'logo' => [
           'path' => '/sites/default/files/logo.jpg',
           'use_default' => TRUE,
@@ -224,10 +223,7 @@ class ConfigOverridesTest extends UnitTestCase {
         break;
 
       case 'su_upload_logo_image':
-        $obj->method('getValue')->willReturn(['target_id' => 1]);
-        $obj->method('first')->will(
-          $this->returnSelf()
-        );
+        $obj->method('getValue')->willReturn([['target_id' => 1]]);
         break;
     }
 

--- a/tests/src/Unit/Config/ConfigOverridesTest.php
+++ b/tests/src/Unit/Config/ConfigOverridesTest.php
@@ -230,4 +230,15 @@ class ConfigOverridesTest extends UnitTestCase {
     return $obj;
   }
 
+  /**
+   * [testCreateConfigObject description]
+   * @return [type] [description]
+   */
+  function testDefaultFunctions() {
+    $this->assertNull($this->overrideService->createConfigObject('name'));
+    $this->assertEquals($this->overrideService->getCacheSuffix(), 'StanfordProfileConfigOverride');
+    $obj = new CacheableMetadata();
+    $this->assertEquals(get_class($obj), get_class($this->overrideService->getCacheableMetadata('name'));
+  }
+
 }

--- a/tests/src/Unit/Config/ConfigOverridesTest.php
+++ b/tests/src/Unit/Config/ConfigOverridesTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Drupal\Tests\stanford_profile\Unit\Config;
+namespace Drupal\Tests\stanford_profile_helper\Unit\Config;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\State\StateInterface;
-use Drupal\stanford_profile\Config\ConfigOverrides;
+use Drupal\stanford_profile_helper\Config\ConfigOverrides;
 use Drupal\Tests\UnitTestCase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\config_pages\ConfigPagesLoaderServiceInterface;
@@ -22,13 +22,13 @@ use Drupal\Core\StreamWrapper\StreamWrapperInterface;
 /**
  * Class ConfigOverridesTest
  *
- * @group stanford_profile
- * @coversDefaultClass \Drupal\stanford_profile\Config\ConfigOverrides
+ * @group stanford_profile_helper
+ * @coversDefaultClass \Drupal\stanford_profile_helper\Config\ConfigOverrides
  */
 class ConfigOverridesTest extends UnitTestCase {
 
   /**
-   * @var \Drupal\stanford_profile\Config\ConfigOverrides
+   * @var \Drupal\stanford_profile_helper_helper\Config\ConfigOverrides
    */
   protected $overrideService;
 

--- a/tests/src/Unit/Config/ConfigOverridesTest.php
+++ b/tests/src/Unit/Config/ConfigOverridesTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Drupal\Tests\stanford_profile\Unit\Config;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\stanford_profile\Config\ConfigOverrides;
+use Drupal\Tests\UnitTestCase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\config_pages\ConfigPagesLoaderServiceInterface;
+use Drupal\config_pages\ConfigPagesInterface;
+use Drupal\config_pages\Entity\ConfigPages;
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\file\Entity\File;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperInterface;
+
+/**
+ * Class ConfigOverridesTest
+ *
+ * @group stanford_profile
+ * @coversDefaultClass \Drupal\stanford_profile\Config\ConfigOverrides
+ */
+class ConfigOverridesTest extends UnitTestCase {
+
+  /**
+   * @var \Drupal\stanford_profile\Config\ConfigOverrides
+   */
+  protected $overrideService;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $state = $this->createMock(StateInterface::class);
+    $state->method('get')->will($this->returnCallback([
+      $this,
+      'getStateCallback',
+    ]));
+
+    $config_pages = $this->createMock(ConfigPagesLoaderServiceInterface::class);
+    $config_factory = $this->createMock(ConfigFactoryInterface::class);
+    $entity_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $stream_wrapper_manager = $this->createMock(StreamWrapperManagerInterface::class);
+
+    $config_factory->method('getEditable')
+      ->will($this->returnCallback([$this, 'getConfigCallback']));
+
+    $this->overrideService = new ConfigOverrides($state, $config_pages, $config_factory, $entity_manager, $stream_wrapper_manager);
+  }
+
+  /**
+   * Lockup custom overrides through config form.
+   */
+  public function testConfigLockupOverrides() {
+
+    $state = $this->createMock(StateInterface::class);
+    $state->method('get')->will($this->returnCallback([
+      $this,
+      'getStateCallback',
+    ]));
+
+    $config_pages = $this->createMock(ConfigPagesLoaderServiceInterface::class);
+    $config_factory = $this->createMock(ConfigFactoryInterface::class);
+    $entity_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $file = $this->createMock(File::class);
+    $entity_storage = $this->createMock(EntityStorageInterface::class);
+    $stream_wrapper_manager = $this->createMock(StreamWrapperManagerInterface::class);
+    $stream_wrapper = $this->createMock(StreamWrapperInterface::class);
+
+    $config_factory->method('getEditable')->will(
+      $this->returnCallback([$this, 'getConfigCallback'])
+    );
+
+    $config_factory->method('get')->will(
+      $this->returnCallback([$this, 'getConfigCallback'])
+    );
+
+    $config_pages->method('load')->will(
+      $this->returnCallback([$this, 'getConfigPageLockup'])
+    );
+
+    $file->method('getFileUri')->willReturn('public://logo.jpg');
+    $entity_storage->method('load')->willReturn($file);
+    $entity_manager->method('getStorage')->willReturn($entity_storage);
+
+    $stream_wrapper->method('getExternalUrl')->willReturn('/sites/default/files/logo.jpg');
+    $stream_wrapper_manager->method('getViaUri')->willReturn($stream_wrapper);
+
+    $overrideService = new ConfigOverrides($state, $config_pages, $config_factory, $entity_manager, $stream_wrapper_manager);
+
+    $overrides = $overrideService->loadOverrides(['stanford_basic.settings']);
+    $expected = ['stanford_basic.settings' =>
+      [
+        'lockup' => [
+          'option' => 'a',
+          'line1' => 'Line 1',
+          'line2' => 'Line 2',
+          'line3' => 'Line 3',
+          'line4' => 'Line 4',
+          'line5' => 'Line 5',
+        ],
+        'use_logo' => TRUE,
+        'logo' => [
+          'path' => '/sites/default/files/logo.jpg',
+          'use_default' => TRUE,
+        ],
+      ],
+    ];
+    $this->assertArrayEquals($expected, $overrides);
+
+    // TEST SOME FAILURES FOR MORE COVERAGE.
+    // -------------------------------------------------------------------------
+
+    // Test to avoid circular ref.
+    $overrides = $overrideService->loadOverrides(['system.theme']);
+
+    // Test a failed get image from config page.
+    $config_page = $this->createMock(ConfigPages::class);
+    $config_page->method('get')->willReturn(FALSE);
+    $config_pages->method('load')->willReturn($config_page);
+    $overrideService = new ConfigOverrides($state, $config_pages, $config_factory, $entity_manager, $stream_wrapper_manager);
+    $overrides = $overrideService->loadOverrides(['stanford_basic.settings']);
+    $this->assertTrue(is_array($overrides));
+
+    // Test a failed get image fid.
+    $obj = $this->createMock(FieldItemListInterface::class);
+    $obj->method('getValue')->willReturn(FALSE);
+    $obj->method('first')->will(
+      $this->returnSelf()
+    );
+    $config_page = $this->createMock(ConfigPages::class);
+    $config_page->method('get')->willReturn($obj);
+    $config_pages->method('load')->willReturn($config_page);
+    $overrideService = new ConfigOverrides($state, $config_pages, $config_factory, $entity_manager, $stream_wrapper_manager);
+    $overrides = $overrideService->loadOverrides(['stanford_basic.settings']);
+    $this->assertTrue(is_array($overrides));
+
+    // Test a failed config page load.
+    $config_pages->method('load')->willReturn(FALSE);
+    $overrideService = new ConfigOverrides($state, $config_pages, $config_factory, $entity_manager, $stream_wrapper_manager);
+    $overrides = $overrideService->loadOverrides(['stanford_basic.settings']);
+    $this->assertTrue(is_array($overrides));
+
+  }
+
+  /**
+   * [getConfigCallback description]
+   * @param  [type] $name [description]
+   * @return [type]       [description]
+   */
+  public function getConfigCallback($name) {
+    $config = $this->createMock(Config::class);
+    $setting = [];
+    switch ($name) {
+      case 'core.extension':
+        $setting = ['stable' => 0, 'seven' => 0];
+        break;
+
+      case 'system.theme':
+        $setting = ['default' => 'stanford_basic'];
+        break;
+    }
+
+    $config->method('getOriginal')->willReturn($setting);
+    $config->method('get')->with('default')->willReturn('stanford_basic');
+    return $config;
+  }
+
+  /**
+   * [getConfigPageLockup description]
+   * @return [type] [description]
+   */
+  function getConfigPageLockup($name) {
+    $config_page = $this->createMock(ConfigPages::class);
+
+    $config_page->method('get')->will(
+      $this->returnCallback([$this, 'getFieldValue'])
+    );
+
+    return $config_page;
+  }
+
+  /**
+   * [getFieldValue description]
+   * @param  [type] $name [description]
+   * @return [type]       [description]
+   */
+  public function getFieldValue($name) {
+    $obj = $this->createMock(FieldItemListInterface::class);
+
+    switch ($name) {
+      case 'su_lockup_options':
+        $obj->method('getString')->willReturn('a');
+        break;
+
+      case 'su_line_1':
+        $obj->method('getString')->willReturn('Line 1');
+        break;
+
+      case 'su_line_2':
+        $obj->method('getString')->willReturn('Line 2');
+        break;
+
+      case 'su_line_3':
+        $obj->method('getString')->willReturn('Line 3');
+        break;
+
+      case 'su_line_4':
+        $obj->method('getString')->willReturn('Line 4');
+        break;
+
+      case 'su_line_5':
+        $obj->method('getString')->willReturn('Line 5');
+        break;
+
+      case 'su_use_theme_logo':
+        $obj->method('getString')->willReturn('1');
+        break;
+
+      case 'su_upload_logo_image':
+        $obj->method('getValue')->willReturn(['target_id' => 1]);
+        $obj->method('first')->will(
+          $this->returnSelf()
+        );
+        break;
+    }
+
+    return $obj;
+  }
+
+}

--- a/tests/src/Unit/Config/ConfigOverridesTest.php
+++ b/tests/src/Unit/Config/ConfigOverridesTest.php
@@ -236,7 +236,7 @@ class ConfigOverridesTest extends UnitTestCase {
    */
   function testDefaultFunctions() {
     $this->assertNull($this->overrideService->createConfigObject('name'));
-    $this->assertEquals($this->overrideService->getCacheSuffix(), 'StanfordProfileConfigOverride');
+    $this->assertEquals($this->overrideService->getCacheSuffix(), 'StanfordProfileHelperConfigOverride');
     $obj = new CacheableMetadata();
     $this->assertEquals(get_class($obj), get_class($this->overrideService->getCacheableMetadata('name')));
   }


### PR DESCRIPTION
# READY FOR REVIEW 

# Summary
- Supporting functions for https://github.com/SU-SWS/stanford_profile/pull/220
- Adds state to config page form and clear render cache on submit

# Needed By (Date)
- Tuesday July 28th

# Urgency
- Medium

# Steps to Test

1. Review code
2. See form at https://lockupsettings-dev.sites.stanford.edu/admin/config/system/lockup-settings for functionality

# Affected Projects or Products
- Cardinalsites
- SOE
- SAA
- Earth Sites
- LelandD8

# Associated Issues and/or People
- D8CORE-1472 and others linked to it
- https://github.com/SU-SWS/stanford_profile/pull/220
- https://github.com/SU-SWS/stanford_basic/pull/170

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
