### PR TITLE
Added presave to remove all field permissions from field storage that arent needed

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -6,19 +6,19 @@
  */
 
 use Drupal\Component\Utility\Html;
-use Drupal\config_pages\ConfigPagesInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Site\Settings;
+use Drupal\Core\Url;
+use Drupal\config_pages\ConfigPagesInterface;
+use Drupal\field\FieldStorageConfigInterface;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
-use Drupal\Core\Url;
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\field\FieldStorageConfigInterface;
 
 /**
  * Implements hook_form_alter().
@@ -82,10 +82,8 @@ function stanford_profile_helper_menu_link_content_presave(MenuLinkContent $enti
   // by the menu cache tags.
   $parent_id = $entity->getParentId();
   if (!empty($parent_id)) {
-    [$entity_name, $uuid] = explode(':', $parent_id);
-    $menu_link_content = \Drupal::entityTypeManager()
-      ->getStorage($entity_name)
-      ->loadByProperties(['uuid' => $uuid]);
+    list($entity_name, $uuid) = explode(':', $parent_id);
+    $menu_link_content = \Drupal::entityTypeManager()->getStorage($entity_name)->loadByProperties(['uuid' => $uuid]);
     if (is_array($menu_link_content)) {
       $parent_item = array_pop($menu_link_content);
       $params = $parent_item->getUrlObject()->getRouteParameters();
@@ -124,8 +122,7 @@ function stanford_profile_helper_entity_field_access($operation, FieldDefinition
  * Implements hook_field_widget_WIDGET_TYPE_form_alter().
  */
 function stanford_profile_helper_field_widget_options_select_form_alter(&$element, FormStateInterface $form_state, $context) {
-  if ($context['items']->getFieldDefinition()
-      ->getName() == 'layout_selection') {
+  if ($context['items']->getFieldDefinition()->getName() == 'layout_selection') {
     $element['#description'] = t('Choose a layout to display the page as a whole. Choose "- None -" to keep the default layout setting.');
   }
 }
@@ -182,8 +179,7 @@ function stanford_profile_helper_form_menu_edit_form_alter(array &$form, FormSta
 
   // If the form is locked, hide the config you cannot change from users without
   // the know how.
-  $access = \Drupal::currentUser()
-    ->hasPermission('Administer menus and menu items');
+  $access = \Drupal::currentUser()->hasPermission('Administer menus and menu items');
   $form['label']['#access'] = $access;
   $form['description']['#access'] = $access;
   $form['id']['#access'] = $access;
@@ -225,8 +221,7 @@ function stanford_profile_helper_config_pages_stanford_basic_site_settings_form_
  * Implements hook_ENTITY_TYPE_presave().
  */
 function stanford_profile_helper_config_pages_presave(ConfigPagesInterface $entity) {
-  if ($entity->hasField('su_site_url') && ($url_field = $entity->get('su_site_url')
-      ->getValue())) {
+  if ($entity->hasField('su_site_url') && ($url_field = $entity->get('su_site_url')->getValue())) {
     // Set the xml sitemap module state to the new domain.
     \Drupal::state()->set('xmlsitemap_base_url', $url_field[0]['uri']);
   }
@@ -246,12 +241,10 @@ function stanford_profile_helper_xmlsitemap_link_alter(array &$link, array $cont
   $node_id = $link['loc'];
 
   // Get 403 page path.
-  $stanford_profile_helper_403_page = \Drupal::config('system.site')
-    ->get('page.403');
+  $stanford_profile_helper_403_page = \Drupal::config('system.site')->get('page.403');
 
   // Get 404 page path.
-  $stanford_profile_helper_404_page = \Drupal::config('system.site')
-    ->get('page.404');
+  $stanford_profile_helper_404_page = \Drupal::config('system.site')->get('page.404');
 
   // If node id matches 403 or 404 pages, remove it from sitemap.
   switch ($node_id) {
@@ -322,25 +315,7 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   // LINE 3.
   $form['su_line_3']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      [
-        '_none',
-        'none',
-        'a',
-        'b',
-        'c',
-        'f',
-        'g',
-        'j',
-        'k',
-        'l',
-        'm',
-        'n',
-        'o',
-        'p',
-        'q',
-        'r',
-        's',
-      ],
+      ['_none', 'none', 'a', 'b', 'c', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's'],
       ':input[name="su_lockup_options"]'
     ),
   ];
@@ -348,23 +323,7 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   // LINE 4.
   $form['su_line_4']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      [
-        '_none',
-        'none',
-        'a',
-        'b',
-        'c',
-        'd',
-        'e',
-        'f',
-        'g',
-        'j',
-        'k',
-        'l',
-        'm',
-        'n',
-        'r',
-      ],
+      ['_none', 'none', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'r'],
       ':input[name="su_lockup_options"]'
     ),
   ];
@@ -372,24 +331,7 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   // LINE 5.
   $form['su_line_5']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      [
-        '_none',
-        'none',
-        'b',
-        'd',
-        'e',
-        'f',
-        'h',
-        'i',
-        'l',
-        'm',
-        'n',
-        'o',
-        'p',
-        'q',
-        's',
-        't',
-      ],
+      ['_none', 'none', 'b', 'd', 'e', 'f', 'h', 'i', 'l', 'm', 'n', 'o', 'p', 'q', 's', 't'],
       ':input[name="su_lockup_options"]'
     ),
   ];
@@ -489,25 +431,7 @@ function stanford_profile_helper_form_config_pages_stanford_local_footer_form_al
   // LINE 3.
   $form['su_local_foot_line_3']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      [
-        '_none',
-        'none',
-        'a',
-        'b',
-        'c',
-        'f',
-        'g',
-        'j',
-        'k',
-        'l',
-        'm',
-        'n',
-        'o',
-        'p',
-        'q',
-        'r',
-        's',
-      ],
+      ['_none', 'none', 'a', 'b', 'c', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's'],
       ':input[name="su_local_foot_loc_op"]'
     ),
   ];
@@ -516,23 +440,7 @@ function stanford_profile_helper_form_config_pages_stanford_local_footer_form_al
   // LINE 4.
   $form['su_local_foot_line_4']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      [
-        '_none',
-        'none',
-        'a',
-        'b',
-        'c',
-        'd',
-        'e',
-        'f',
-        'g',
-        'j',
-        'k',
-        'l',
-        'm',
-        'n',
-        'r',
-      ],
+      ['_none', 'none', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'r'],
       ':input[name="su_local_foot_loc_op"]'
     ),
   ];
@@ -541,24 +449,7 @@ function stanford_profile_helper_form_config_pages_stanford_local_footer_form_al
   // LINE 5.
   $form['su_local_foot_line_5']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      [
-        '_none',
-        'none',
-        'b',
-        'd',
-        'e',
-        'f',
-        'h',
-        'i',
-        'l',
-        'm',
-        'n',
-        'o',
-        'p',
-        'q',
-        's',
-        't',
-      ],
+      ['_none', 'none', 'b', 'd', 'e', 'f', 'h', 'i', 'l', 'm', 'n', 'o', 'p', 'q', 's', 't'],
       ':input[name="su_local_foot_loc_op"]'
     ),
   ];
@@ -648,8 +539,7 @@ function stanford_profile_helper_preprocess_pattern_alert(&$variables) {
 
     // Validate that the entity has the field we need so we don't 500 the site.
     if (!$entity->hasField('su_global_msg_type')) {
-      \Drupal::logger('stanford_profile_helper')
-        ->error(t("Global Messages Config Block is missing the field su_global_msg_type"));
+      \Drupal::logger('stanford_profile_helper')->error(t("Global Messages Config Block is missing the field su_global_msg_type"));
       return;
     }
 
@@ -691,8 +581,7 @@ function stanford_profile_helper_preprocess_pattern_localfooter(&$variables) {
     $variables['line3'] = $entity->get('su_local_foot_line_3')->getString();
     $variables['line4'] = $entity->get('su_local_foot_line_4')->getString();
     $variables['line5'] = $entity->get('su_local_foot_line_5')->getString();
-    $variables['use_logo'] = $entity->get('su_local_foot_use_logo')
-      ->getString();
+    $variables['use_logo'] = $entity->get('su_local_foot_use_logo')->getString();
     $file_field = $entity->get('su_local_foot_loc_img');
 
     // Check if there is a file.

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -627,5 +627,6 @@ function stanford_profile_helper_field_storage_config_presave(FieldStorageConfig
   // those third party settings before save so that it keeps the config clean.
   if ($field_storage->getThirdPartySetting('field_permissions', 'permission_type') === 'public') {
     $field_storage->unsetThirdPartySetting('field_permissions', 'permission_type');
+    $field_storage->calculateDependencies();
   }
 }

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -18,6 +18,7 @@ use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\field\FieldStorageConfigInterface;
 
 /**
  * Implements hook_form_alter().
@@ -81,8 +82,10 @@ function stanford_profile_helper_menu_link_content_presave(MenuLinkContent $enti
   // by the menu cache tags.
   $parent_id = $entity->getParentId();
   if (!empty($parent_id)) {
-    list($entity_name, $uuid) = explode(':', $parent_id);
-    $menu_link_content = \Drupal::entityTypeManager()->getStorage($entity_name)->loadByProperties(['uuid' => $uuid]);
+    [$entity_name, $uuid] = explode(':', $parent_id);
+    $menu_link_content = \Drupal::entityTypeManager()
+      ->getStorage($entity_name)
+      ->loadByProperties(['uuid' => $uuid]);
     if (is_array($menu_link_content)) {
       $parent_item = array_pop($menu_link_content);
       $params = $parent_item->getUrlObject()->getRouteParameters();
@@ -121,7 +124,8 @@ function stanford_profile_helper_entity_field_access($operation, FieldDefinition
  * Implements hook_field_widget_WIDGET_TYPE_form_alter().
  */
 function stanford_profile_helper_field_widget_options_select_form_alter(&$element, FormStateInterface $form_state, $context) {
-  if ($context['items']->getFieldDefinition()->getName() == 'layout_selection') {
+  if ($context['items']->getFieldDefinition()
+      ->getName() == 'layout_selection') {
     $element['#description'] = t('Choose a layout to display the page as a whole. Choose "- None -" to keep the default layout setting.');
   }
 }
@@ -178,7 +182,8 @@ function stanford_profile_helper_form_menu_edit_form_alter(array &$form, FormSta
 
   // If the form is locked, hide the config you cannot change from users without
   // the know how.
-  $access = \Drupal::currentUser()->hasPermission('Administer menus and menu items');
+  $access = \Drupal::currentUser()
+    ->hasPermission('Administer menus and menu items');
   $form['label']['#access'] = $access;
   $form['description']['#access'] = $access;
   $form['id']['#access'] = $access;
@@ -220,7 +225,8 @@ function stanford_profile_helper_config_pages_stanford_basic_site_settings_form_
  * Implements hook_ENTITY_TYPE_presave().
  */
 function stanford_profile_helper_config_pages_presave(ConfigPagesInterface $entity) {
-  if ($entity->hasField('su_site_url') && ($url_field = $entity->get('su_site_url')->getValue())) {
+  if ($entity->hasField('su_site_url') && ($url_field = $entity->get('su_site_url')
+      ->getValue())) {
     // Set the xml sitemap module state to the new domain.
     \Drupal::state()->set('xmlsitemap_base_url', $url_field[0]['uri']);
   }
@@ -240,10 +246,12 @@ function stanford_profile_helper_xmlsitemap_link_alter(array &$link, array $cont
   $node_id = $link['loc'];
 
   // Get 403 page path.
-  $stanford_profile_helper_403_page = \Drupal::config('system.site')->get('page.403');
+  $stanford_profile_helper_403_page = \Drupal::config('system.site')
+    ->get('page.403');
 
   // Get 404 page path.
-  $stanford_profile_helper_404_page = \Drupal::config('system.site')->get('page.404');
+  $stanford_profile_helper_404_page = \Drupal::config('system.site')
+    ->get('page.404');
 
   // If node id matches 403 or 404 pages, remove it from sitemap.
   switch ($node_id) {
@@ -314,7 +322,25 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   // LINE 3.
   $form['su_line_3']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      ['_none', 'none', 'a', 'b', 'c', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's'],
+      [
+        '_none',
+        'none',
+        'a',
+        'b',
+        'c',
+        'f',
+        'g',
+        'j',
+        'k',
+        'l',
+        'm',
+        'n',
+        'o',
+        'p',
+        'q',
+        'r',
+        's',
+      ],
       ':input[name="su_lockup_options"]'
     ),
   ];
@@ -322,7 +348,23 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   // LINE 4.
   $form['su_line_4']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      ['_none', 'none', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'r'],
+      [
+        '_none',
+        'none',
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+        'f',
+        'g',
+        'j',
+        'k',
+        'l',
+        'm',
+        'n',
+        'r',
+      ],
       ':input[name="su_lockup_options"]'
     ),
   ];
@@ -330,7 +372,24 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter(ar
   // LINE 5.
   $form['su_line_5']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      ['_none', 'none', 'b', 'd', 'e', 'f', 'h', 'i', 'l', 'm', 'n', 'o', 'p', 'q', 's', 't'],
+      [
+        '_none',
+        'none',
+        'b',
+        'd',
+        'e',
+        'f',
+        'h',
+        'i',
+        'l',
+        'm',
+        'n',
+        'o',
+        'p',
+        'q',
+        's',
+        't',
+      ],
       ':input[name="su_lockup_options"]'
     ),
   ];
@@ -430,7 +489,25 @@ function stanford_profile_helper_form_config_pages_stanford_local_footer_form_al
   // LINE 3.
   $form['su_local_foot_line_3']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      ['_none', 'none', 'a', 'b', 'c', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's'],
+      [
+        '_none',
+        'none',
+        'a',
+        'b',
+        'c',
+        'f',
+        'g',
+        'j',
+        'k',
+        'l',
+        'm',
+        'n',
+        'o',
+        'p',
+        'q',
+        'r',
+        's',
+      ],
       ':input[name="su_local_foot_loc_op"]'
     ),
   ];
@@ -439,7 +516,23 @@ function stanford_profile_helper_form_config_pages_stanford_local_footer_form_al
   // LINE 4.
   $form['su_local_foot_line_4']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      ['_none', 'none', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'j', 'k', 'l', 'm', 'n', 'r'],
+      [
+        '_none',
+        'none',
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+        'f',
+        'g',
+        'j',
+        'k',
+        'l',
+        'm',
+        'n',
+        'r',
+      ],
       ':input[name="su_local_foot_loc_op"]'
     ),
   ];
@@ -448,7 +541,24 @@ function stanford_profile_helper_form_config_pages_stanford_local_footer_form_al
   // LINE 5.
   $form['su_local_foot_line_5']['widget']['0']['value']['#states'] = [
     'invisible' => _stanford_profile_helper_get_lockup_states(
-      ['_none', 'none', 'b', 'd', 'e', 'f', 'h', 'i', 'l', 'm', 'n', 'o', 'p', 'q', 's', 't'],
+      [
+        '_none',
+        'none',
+        'b',
+        'd',
+        'e',
+        'f',
+        'h',
+        'i',
+        'l',
+        'm',
+        'n',
+        'o',
+        'p',
+        'q',
+        's',
+        't',
+      ],
       ':input[name="su_local_foot_loc_op"]'
     ),
   ];
@@ -538,7 +648,8 @@ function stanford_profile_helper_preprocess_pattern_alert(&$variables) {
 
     // Validate that the entity has the field we need so we don't 500 the site.
     if (!$entity->hasField('su_global_msg_type')) {
-      \Drupal::logger('stanford_profile_helper')->error(t("Global Messages Config Block is missing the field su_global_msg_type"));
+      \Drupal::logger('stanford_profile_helper')
+        ->error(t("Global Messages Config Block is missing the field su_global_msg_type"));
       return;
     }
 
@@ -580,7 +691,8 @@ function stanford_profile_helper_preprocess_pattern_localfooter(&$variables) {
     $variables['line3'] = $entity->get('su_local_foot_line_3')->getString();
     $variables['line4'] = $entity->get('su_local_foot_line_4')->getString();
     $variables['line5'] = $entity->get('su_local_foot_line_5')->getString();
-    $variables['use_logo'] = $entity->get('su_local_foot_use_logo')->getString();
+    $variables['use_logo'] = $entity->get('su_local_foot_use_logo')
+      ->getString();
     $file_field = $entity->get('su_local_foot_loc_img');
 
     // Check if there is a file.
@@ -615,5 +727,16 @@ function stanford_profile_helper_form_media_library_add_form_embeddable_alter(ar
 
   if (isset($form['container']['field_media_embeddable_code'])) {
     $form['container']['field_media_embeddable_code']['#access'] = $authorized;
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function stanford_profile_helper_field_storage_config_presave(FieldStorageConfigInterface $field_storage) {
+  // If a field is saved and the field permissions are public, lets just remove
+  // those third party settings before save so that it keeps the config clean.
+  if ($field_storage->getThirdPartySetting('field_permissions', 'permission_type') === 'public') {
+    $field_storage->unsetThirdPartySetting('field_permissions', 'permission_type');
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Before field storage save, remove the field permissions third party settings if we don't need it
- see https://github.com/SU-SWS/stanford_profile/pull/295

# Need Review By (Date)
- :man_shrugging:

# Urgency
- low

# Steps to Test
1. checkout this branch and clear cache
1. create a new field on any entity
1. export the config
1. verify the exported config doesn't have the field permissions module as a dependency.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
