### PR TITLE
D8CORE-2644: Added additional help text and snow form links

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -621,7 +621,7 @@ function stanford_profile_helper_form_media_library_add_form_embeddable_alter(ar
     $form['container'][$embed_code_field]['#access'] = $authorized;
   }
 
-  if ( isset($form['container'][$source_field]) ){
+  if (isset($form['container'][$source_field])) {
     $new_desc = 'Allowed providers: @providers. For custom embeds, please <a href="@snow_form">request support.</a>';
     $args = $form['container'][$source_field]['#description']->getArguments();
     $args['@snow_form'] = 'https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=83daed294f4143009a9a97411310c70a';
@@ -630,7 +630,6 @@ function stanford_profile_helper_form_media_library_add_form_embeddable_alter(ar
   }
 
 }
-
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -654,5 +653,3 @@ function stanford_profile_helper_form_media_embeddable_add_form_alter(&$form, Fo
 function stanford_profile_helper_form_media_embeddable_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   stanford_profile_helper_form_media_embeddable_add_form_alter($form, $form_state, $form_id);
 }
-
-

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -18,6 +18,7 @@ use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Component\Render\FormattableMarkup;
 
 /**
  * Implements hook_form_alter().
@@ -609,11 +610,49 @@ function stanford_profile_helper_preprocess_pattern_localfooter(&$variables) {
  * Implements hook_form_FORM_ID_alter().
  */
 function stanford_profile_helper_form_media_library_add_form_embeddable_alter(array &$form, FormStateInterface $form_state) {
+
+  $source_field = $form_state->get('source_field');
+  $embed_code_field = $form_state->get('unstructured_field_name');
   $user = \Drupal::currentUser();
   $authorized = $user->hasPermission('create field_media_embeddable_code')
     || $user->hasPermission('edit field_media_embeddable_code');
 
-  if (isset($form['container']['field_media_embeddable_code'])) {
-    $form['container']['field_media_embeddable_code']['#access'] = $authorized;
+  if (isset($form['container'][$embed_code_field])) {
+    $form['container'][$embed_code_field]['#access'] = $authorized;
   }
+
+  if ( isset($form['container'][$source_field]) ){
+    $new_desc = 'Allowed providers: @providers. For custom embeds, please <a href="@snow_form">request support.</a>';
+    $args = $form['container'][$source_field]['#description']->getArguments();
+    $args['@snow_form'] = 'https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=83daed294f4143009a9a97411310c70a';
+    $form['container'][$source_field]['#description'] = new FormattableMarkup($new_desc, $args);
+    $form['container'][$source_field]['#title'] = t('oEmbed URL');
+  }
+
 }
+
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function stanford_profile_helper_form_media_embeddable_add_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $source_config = $form_state
+    ->getFormObject()
+    ->getEntity()
+    ->getSource()
+    ->getConfiguration();
+  $source_field = $source_config['oembed_field_name'];
+  $new_desc = 'Allowed providers: @providers. For custom embeds, please <a href="@snow_form">request support.</a>';
+  $args = $form[$source_field]['widget'][0]['value']['#description']->getArguments();
+  $args['@snow_form'] = 'https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=83daed294f4143009a9a97411310c70a';
+  $form[$source_field]['widget'][0]['value']['#description'] = new FormattableMarkup($new_desc, $args);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function stanford_profile_helper_form_media_embeddable_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  stanford_profile_helper_form_media_embeddable_add_form_alter($form, $form_state, $form_id);
+}
+
+

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -18,7 +18,6 @@ use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Url;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Component\Render\FormattableMarkup;
 
 /**
  * Implements hook_form_alter().
@@ -622,10 +621,12 @@ function stanford_profile_helper_form_media_library_add_form_embeddable_alter(ar
   }
 
   if (isset($form['container'][$source_field])) {
-    $new_desc = 'Allowed providers: @providers. For custom embeds, please <a href="@snow_form">request support.</a>';
-    $args = $form['container'][$source_field]['#description']->getArguments();
-    $args['@snow_form'] = 'https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=83daed294f4143009a9a97411310c70a';
-    $form['container'][$source_field]['#description'] = new FormattableMarkup($new_desc, $args);
+    if (!$authorized) {
+      $new_desc = 'Allowed providers: @providers. For custom embeds, please <a href="@snow_form">request support.</a>';
+      $args = $form['container'][$source_field]['#description']->getArguments();
+      $args['@snow_form'] = 'https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=83daed294f4143009a9a97411310c70a';
+      $form['container'][$source_field]['#description'] = t($new_desc, $args);
+    }
     $form['container'][$source_field]['#title'] = t('oEmbed URL');
   }
 
@@ -635,16 +636,22 @@ function stanford_profile_helper_form_media_library_add_form_embeddable_alter(ar
  * Implements hook_form_FORM_ID_alter().
  */
 function stanford_profile_helper_form_media_embeddable_add_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $source_config = $form_state
-    ->getFormObject()
-    ->getEntity()
-    ->getSource()
-    ->getConfiguration();
-  $source_field = $source_config['oembed_field_name'];
-  $new_desc = 'Allowed providers: @providers. For custom embeds, please <a href="@snow_form">request support.</a>';
-  $args = $form[$source_field]['widget'][0]['value']['#description']->getArguments();
-  $args['@snow_form'] = 'https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=83daed294f4143009a9a97411310c70a';
-  $form[$source_field]['widget'][0]['value']['#description'] = new FormattableMarkup($new_desc, $args);
+  $user = \Drupal::currentUser();
+  $authorized = $user->hasPermission('create field_media_embeddable_code')
+    || $user->hasPermission('edit field_media_embeddable_code');
+  if (!$authorized) {
+    $source_config = $form_state
+      ->getFormObject()
+      ->getEntity()
+      ->getSource()
+      ->getConfiguration();
+    $source_field = $source_config['oembed_field_name'];
+    $new_desc = 'Allowed providers: @providers. For custom embeds, please <a href="@snow_form">request support.</a>';
+    $args = $form[$source_field]['widget'][0]['value']['#description']->getArguments();
+    $args['@snow_form'] = 'https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=83daed294f4143009a9a97411310c70a';
+    $form[$source_field]['widget'][0]['value']['#description'] = t($new_desc, $args);
+  }
+
 }
 
 /**

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -645,7 +645,7 @@ function stanford_profile_helper_form_media_embeddable_add_form_alter(&$form, Fo
       ->getEntity()
       ->getSource()
       ->getConfiguration();
-    $source_field = $source_config['oembed_field_name'];
+    $source_field = $source_config['source_field'];
     $new_desc = 'Allowed providers: @providers. For custom embeds, please <a href="@snow_form">request support.</a>';
     $args = $form[$source_field]['widget'][0]['value']['#description']->getArguments();
     $args['@snow_form'] = 'https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=83daed294f4143009a9a97411310c70a';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Per Ishi's feedback, we needed a little more consistency between the media library embeddable forms and the wysiwyg embeddables form.  We do these changes in the stanford_profile_helper repo, since they are only for our profiles, and not needed in the stanford_media module itself.

# Needed By (Date)
- next code cutoff.

# Urgency
- 3 out of 10.

# Steps to Test

1. Install this version of the module.
2. Browse to /media/add/embeddable
3. Verify the oEmbed field is labeled 'oEmbed URL'
4. Verify there is a link to the SNOW form in the help text below the oEmbed field.
5. Try to add a new Embeddable through the WYSIWYG.  Confirm the labels and the SNOW form link match correctly.

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People

- https://github.com/SU-SWS/stanford_profile/pull/299  <-- tests.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
