### PR TITLE
D8CORE-2613: Delete taxonomy menu links when the parents change

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -82,7 +82,7 @@ function stanford_profile_helper_menu_link_content_presave(MenuLinkContent $enti
   // by the menu cache tags.
   $parent_id = $entity->getParentId();
   if (!empty($parent_id)) {
-    [$entity_name, $uuid] = explode(':', $parent_id);
+    list($entity_name, $uuid) = explode(':', $parent_id);
     $menu_link_content = \Drupal::entityTypeManager()->getStorage($entity_name)->loadByProperties(['uuid' => $uuid]);
     if (is_array($menu_link_content)) {
       $parent_item = array_pop($menu_link_content);

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -8,7 +8,6 @@
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\Cache;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -19,6 +18,7 @@ use Drupal\config_pages\ConfigPagesInterface;
 use Drupal\field\FieldStorageConfigInterface;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
 
 /**
  * Implements hook_form_alter().
@@ -82,7 +82,7 @@ function stanford_profile_helper_menu_link_content_presave(MenuLinkContent $enti
   // by the menu cache tags.
   $parent_id = $entity->getParentId();
   if (!empty($parent_id)) {
-    list($entity_name, $uuid) = explode(':', $parent_id);
+    [$entity_name, $uuid] = explode(':', $parent_id);
     $menu_link_content = \Drupal::entityTypeManager()->getStorage($entity_name)->loadByProperties(['uuid' => $uuid]);
     if (is_array($menu_link_content)) {
       $parent_item = array_pop($menu_link_content);
@@ -518,10 +518,25 @@ function stanford_profile_helper_form_config_pages_lockup_settings_form_alter_su
 /**
  * Implements hook_entity_type_update().
  */
-function stanford_profile_helper_taxonomy_term_update(EntityInterface $entity) {
-
+function stanford_profile_helper_taxonomy_term_update(TermInterface $entity) {
   // https://www.drupal.org/project/taxonomy_menu/issues/2867626
-  if ("hierarchy" == $entity->bundle()) {
+  $original_parent = $entity->original->get('parent')->getString();
+  if ($original_parent == $entity->get('parent')->getString()) {
+    return;
+  }
+  $database = \Drupal::database();
+  $menu_link_exists = $database->select('menu_tree', 'm')->fields('m')
+    ->condition('id', 'taxonomy_menu.menu_link%', 'LIKE')
+    ->condition('route_param_key', 'taxonomy_term=' . $entity->id())
+    ->countQuery()
+    ->execute()
+    ->fetchField();
+
+  if ($menu_link_exists > 0) {
+    $database->delete('menu_tree')
+      ->condition('id', 'taxonomy_menu.menu_link%', 'LIKE')
+      ->condition('route_param_key', 'taxonomy_term=' . $entity->id())
+      ->execute();
     \Drupal::service('router.builder')->rebuild();
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix the problem when taxonomy terms are moved around and needs to rebuild the menu.

# Need Review By (Date)
- asap

# Urgency
- high

# Steps to Test
1. Add a new taxonomy item for people and nest it under "staff"
2. Refresh /people page and see no new taxonomy items
3. Edit the taxonomy for people and move the new taxonomy item to the top level 
4. Refresh /people page and see the new taxonomy item in the position you placed it in the taxonomy
5. Edit the taxonomy for people and move the new taxonomy item back under another item
6. Refresh the /people page and see the new taxonomy item is gone

Tests are in https://github.com/SU-SWS/stanford_profile/pull/305

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
