### PR TITLE
D8CORE-2184 Adjust taxonomy terms to only 1 parent

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -34,6 +34,18 @@ function stanford_profile_helper_form_alter(&$form, FormStateInterface $form_sta
 }
 
 /**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function stanford_profile_helper_form_taxonomy_term_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Tweak the taxonomy term add/edit form.
+  if (!empty($form['relations']['parent'])) {
+    $form['relations']['parent']['#multiple'] = FALSE;
+    $form['relations']['parent']['#title'] = t('Parent term');
+    $form['relations']['parent']['#description'] = t('Select the appropriate parent item for this term.');
+  }
+}
+
+/**
  * Implements hook_menu_links_discovered_alter().
  */
 function stanford_profile_helper_menu_links_discovered_alter(&$links) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Limit taxonomy terms to 1 parent
- Added help text on taxonomy term form.

# Need Review By (Date)
- 10/14

# Urgency
- low

# Steps to Test
1. checkout this branch and clear caches
1. go to create a new taxonomy term
1. verify you can only choose 1 parent.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
