### PR TITLE
D8CORE-000 Fixed breaking if the parent menu item is external

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -116,12 +116,19 @@ function stanford_profile_helper_menu_link_content_presave(MenuLinkContent $enti
   $parent_id = $entity->getParentId();
   if (!empty($parent_id)) {
     [$entity_name, $uuid] = explode(':', $parent_id);
-    $menu_link_content = \Drupal::entityTypeManager()->getStorage($entity_name)->loadByProperties(['uuid' => $uuid]);
+    $menu_link_content = \Drupal::entityTypeManager()
+      ->getStorage($entity_name)
+      ->loadByProperties(['uuid' => $uuid]);
+
     if (is_array($menu_link_content)) {
       $parent_item = array_pop($menu_link_content);
-      $params = $parent_item->getUrlObject()->getRouteParameters();
-      if (isset($params['node'])) {
-        Cache::invalidateTags(['node:' . $params['node']]);
+      /** @var \Drupal\Core\Url $url */
+      $url = $parent_item->getUrlObject();
+      if (!$url->isExternal()) {
+        $params = $url->getRouteParameters();
+        if (isset($params['node'])) {
+          Cache::invalidateTags(['node:' . $params['node']]);
+        }
       }
     }
   }

--- a/tests/codeception/acceptance/ContentCest.php
+++ b/tests/codeception/acceptance/ContentCest.php
@@ -1,0 +1,19 @@
+<?php
+
+class ContentCest {
+
+  public function testExternalParentLinks(AcceptanceTester $I) {
+   $I->createEntity([
+      'title' => 'Foo',
+      'link' => 'http://stanford.edu',
+    ], 'menu_link_content');
+   $I->logInWithRole('administrator');
+   $I->amOnPage('/admin/structure/menu/manage/main/add');
+   $I->fillField('Menu link title', 'Bar');
+   $I->fillField('Link', 'http://stanford.edu');
+   $I->selectOption('Parent link','-- Foo');
+   $I->click('Save');
+   $I->canSee('The menu link has been saved');
+  }
+
+}

--- a/tests/codeception/acceptance/ContentCest.php
+++ b/tests/codeception/acceptance/ContentCest.php
@@ -1,7 +1,13 @@
 <?php
 
+/**
+ * Class ContentCest.
+ */
 class ContentCest {
 
+  /**
+   * If the parent item is external or absolute, child items shouldn't break.
+   */
   public function testExternalParentLinks(AcceptanceTester $I) {
    $I->createEntity([
       'title' => 'Foo',


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- If the parent menu is external or absolute, not break when adding children links.

# Need Review By (Date)
- 10/20

# Urgency
- medium

# Steps to Test
1. checkout this branch
1. create a parent menu item (via node or just a regular menu item) with a full absolute url to anything
1. create another menu item with any url and choose to put it under the parent item you created earlier
1. verify when you save it doesn't blow up.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
