### PR TITLE
D8CORE-2875: Limit paragraph choices for now

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -758,3 +758,18 @@ function stanford_profile_helper_react_paragraphs_form_field_data_alter(array &$
     }
   }
 }
+
+/**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ */
+function stanford_profile_helper_field_widget_react_paragraphs_form_alter(&$element, FormStateInterface $form_state, $context) {
+  // To limit which sites get the lists and entity reference paragraphs, use
+  // state. This will eventually not be needed.
+  if (\Drupal::state()->get('stanford_profile_allow_all_paragraphs')) {
+    return;
+  }
+  $tools = &$element['container']['value']['#attached']['drupalSettings']['reactParagraphs'][0]['tools'];
+  $tools = array_filter($tools, function ($tool) {
+    return !in_array($tool['id'], ['stanford_lists', 'stanford_entity']);
+  });
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Don't allow the lists and entity reference paragraph types OOTB. We'll give access to a subset of sites at first to allow any unknown bugs to be discovered.
- https://github.com/SU-SWS/stanford_profile/pull/312

# Need Review By (Date)
- 10/30

# Urgency
- medium

# Steps to Test
1. Checkout this branch
1. edit/create a basic page
1. see that you don't have the paragraph options for lists or content reference
1. `drush sset stanford_profile_allow_all_paragraphs 1`
1. edit/create a basic page
1. see that you now have the paragraph options for lists and content reference

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
