### PR TITLE
D8CORE-2183 Keep the relations fieldset open by default on term form

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -40,6 +40,7 @@ function stanford_profile_helper_form_alter(&$form, FormStateInterface $form_sta
 function stanford_profile_helper_form_taxonomy_term_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Tweak the taxonomy term add/edit form.
   if (!empty($form['relations']['parent'])) {
+    $form['relations']['#open'] = TRUE;
     $form['relations']['parent']['#multiple'] = FALSE;
     $form['relations']['parent']['#title'] = t('Parent term');
     $form['relations']['parent']['#description'] = t('Select the appropriate parent item for this term.');


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Keep relations fieldset open on taxonomy term forms.

# Need Review By (Date)
- 11/5

# Urgency
- low

# Steps to Test
1. checkout this branch.
1. edit/create a taxonomy term
1. verify the relations group is open.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
