### PR TITLE
D8CORE-2668 Removed title attribute from taxonomy menu items

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -20,6 +20,7 @@ use Drupal\field\FieldStorageConfigInterface;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
+use Drupal\taxonomy_menu\Plugin\Menu\TaxonomyMenuMenuLink;
 
 /**
  * Implements hook_form_alter().
@@ -785,4 +786,20 @@ function stanford_profile_helper_field_widget_react_paragraphs_form_alter(&$elem
     return !in_array($tool['id'], ['stanford_lists', 'stanford_entity']);
   });
   $tools = array_values($tools);
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function stanford_profile_helper_preprocess_menu(&$variables) {
+  foreach ($variables['items'] as &$item) {
+    // Taxonomy menu link items use the description from the term as the title
+    // attribute. The description can be very long and could contain HTML. To
+    // Make things easiest, just remove the title attribute.
+    if ($item['original_link'] instanceof TaxonomyMenuMenuLink) {
+      $attributes = $item['url']->getOption('attributes');
+      unset($attributes['title']);
+      $item['url']->setOption('attributes', $attributes);
+    }
+  }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Removed title attribute that has special characters and is super long.

# Need Review By (Date)
- 12/3

# Urgency
- medium

# Steps to Test
1. checkout this branch and clear caches
1. view the `/people` page
1. inspect the sidebar menu items
1. verify the links don't contain a `title` attribute.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
