### PR TITLE
limit the publication views in the viewfield

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -757,6 +757,7 @@ function stanford_profile_helper_react_paragraphs_form_field_data_alter(array &$
       'vertical_teaser_term_list',
       'vertical_teaser_term',
     ],
+    'stanford_publications' => ['related', 'term_list_chicago'],
   ];
   foreach ($remove as $view_id => $remove_displays) {
     if (isset($info['displays'][$view_id])) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove the views from the publication view for the viewfield.

# Need Review By (Date)
- 2/3

# Urgency
- high

# Steps to Test
1. checkout this branch
2. `drush sset stanford_profile_allow_all_paragraphs 1`
2. create a basic page
3. add a list paragraph type
4. ensure you only get the "APA List" and "Chicago List" from the publications view options.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
