### PR TITLE
Set config entity uuids when they are created if they dont match

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -28,7 +28,7 @@ use Drupal\taxonomy_menu\Plugin\Menu\TaxonomyMenuMenuLink;
  * Implements hook_entity_presave().
  */
 function stanford_profile_helper_entity_presave(EntityInterface $entity) {
-  if ($entity instanceof ConfigEntityInterface) {
+  if ($entity instanceof ConfigEntityInterface && $entity->isNew()) {
     /** @var \Drupal\Core\Config\StorageInterface $config_storage */
     $config_storage = \Drupal::service('config.storage.sync');
 

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -8,6 +8,8 @@
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -21,6 +23,29 @@ use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
 use Drupal\taxonomy_menu\Plugin\Menu\TaxonomyMenuMenuLink;
+
+/**
+ * Implements hook_entity_presave().
+ */
+function stanford_profile_helper_entity_presave(EntityInterface $entity) {
+  if ($entity instanceof ConfigEntityInterface) {
+    /** @var \Drupal\Core\Config\StorageInterface $config_storage */
+    $config_storage = \Drupal::service('config.storage.sync');
+
+    // The entity exists in the config sync directory, lets check if it's uuid
+    // matches.
+    if (in_array($entity->getConfigDependencyName(), $config_storage->listAll())) {
+      $staged_config = $config_storage->read($entity->getConfigDependencyName());
+
+      // The uuid of the entity doesn't match that of the config in the sync
+      // directory. Make sure they match so that we don't get config sync
+      // issues.
+      if (isset($staged_config['uuid']) && $staged_config['uuid'] != $entity->uuid()) {
+        $entity->set('uuid', $staged_config['uuid']);
+      }
+    }
+  }
+}
 
 /**
  * Implements hook_form_alter().


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- During config sync, theres a part where it creates a migration_group entity. When it does that, it doesn't set the UUIDs to match the config sync. This causes a circular issue because the config sync will try to delete and re-create it. each time with non-matching uuids. This PR sets the UUID to match the config sync file during save.
-  see https://gitlab.com/drupalspoons/migrate_plus/-/blob/8.x-5.x/migrate_plus.module#L56

# Need Review By (Date)
- 2/4

# Urgency
- high

# Steps to Test
1. delete a config entity (field or node type or something)
2. recreate it with the same name
3. check to make sure the UUID still matches that from the config sync directory.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
