### PR TITLE
D8CORE-3476 Create a new view display mode specific for viewfields

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -17,7 +17,6 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\Url;
 use Drupal\config_pages\ConfigPagesInterface;
-use Drupal\field\FieldConfigInterface;
 use Drupal\field\FieldStorageConfigInterface;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeInterface;

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -768,41 +768,6 @@ function stanford_profile_helper_field_storage_config_presave(FieldStorageConfig
 }
 
 /**
- * Implements hook_react_paragraphs_form_field_data_alter().
- */
-function stanford_profile_helper_react_paragraphs_form_field_data_alter(array &$info, array $field_element, FieldConfigInterface $field_config) {
-  if ($field_config->getName() != 'su_list_view') {
-    return;
-  }
-  $remove = [
-    'stanford_events' => [
-      'list_page_filtered',
-      'more_events_block',
-      'schedule',
-    ],
-    'stanford_news' => [
-      'term_block',
-      'topics_list',
-      'vertical_teaser_term_list',
-      'vertical_teaser_term',
-    ],
-    'stanford_publications' => ['related', 'term_list_chicago', 'pub_type'],
-  ];
-  foreach ($remove as $view_id => $remove_displays) {
-    if (isset($info['displays'][$view_id])) {
-      $info['displays'][$view_id] = array_filter($info['displays'][$view_id], function ($display) use ($remove_displays) {
-        return !in_array($display['value'], $remove_displays);
-      });
-      $info['displays'][$view_id] = array_values($info['displays'][$view_id]);
-
-      if (empty($info['displays'][$view_id])) {
-        unset($info['displays'][$view_id]);
-      }
-    }
-  }
-}
-
-/**
  * Implements hook_field_widget_WIDGET_TYPE_form_alter().
  */
 function stanford_profile_helper_field_widget_react_paragraphs_form_alter(&$element, FormStateInterface $form_state, $context) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- use the custom `viewfield_block` so that we can have different blocks allowed in the viewfield fields.
- It doesn't change any underlying functionality, it just allows for 2 identical block categories.

# Need Review By (Date)
- 3/3

# Urgency
- medium

# Steps to Test
1. Follow the steps in https://github.com/SU-SWS/stanford_profile/pull/370

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
