### PR TITLE
D8CORE-4194 Set the link title value for media caption paragraphs

### DIFF
--- a/stanford_profile_helper.post_update.php
+++ b/stanford_profile_helper.post_update.php
@@ -87,7 +87,7 @@ function stanford_profile_helper_post_update_8100() {
     }
 
     if ($title) {
-      $value['title'] = $title;
+      $value['title'] = trim($title);
       $paragraph->set('su_media_caption_link', [$value])->save();
     }
   }

--- a/stanford_profile_helper.post_update.php
+++ b/stanford_profile_helper.post_update.php
@@ -60,7 +60,7 @@ function stanford_profile_helper_post_update_8100() {
       }
 
       // Absolute external url, fetch the contents of the page and grab the
-      // `<title>` value
+      // `<title>` value.
       if ($url->isExternal()) {
         $page = file_get_contents($url->toString());
         $title = preg_match('/<title[^>]*>(.*?)<\/title>/ims', $page, $match) ? $match[1] : NULL;
@@ -77,7 +77,8 @@ function stanford_profile_helper_post_update_8100() {
           throw new \Exception('Trigger log');
         }
       }
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       \Drupal::logger('stanford_profile_helper')
         ->error('Unable to set link title for paragraph %id with url %url', [
           '%id' => $paragraph->id(),

--- a/stanford_profile_helper.post_update.php
+++ b/stanford_profile_helper.post_update.php
@@ -6,6 +6,7 @@
  */
 
 use Drupal\block_content\Entity\BlockContent;
+use Drupal\Core\Url;
 
 /**
  * Create the events and news intro block content.
@@ -28,4 +29,66 @@ function stanford_profile_helper_post_update_8000(&$sandbox) {
  */
 function stanford_profile_helper_post_update_8001() {
   \Drupal::state()->delete('stanford_profile_allow_all_paragraphs');
+}
+
+/**
+ * Set the link title for media caption paragraph link fields.
+ */
+function stanford_profile_helper_post_update_8100() {
+  $paragraph_storage = \Drupal::entityTypeManager()
+    ->getStorage('paragraph');
+  $entity_ids = $paragraph_storage->getQuery()
+    ->accessCheck(FALSE)
+    ->condition('type', 'stanford_media_caption')
+    ->exists('su_media_caption_link')
+    ->execute();
+
+  foreach ($paragraph_storage->loadMultiple($entity_ids) as $paragraph) {
+    $value = $paragraph->get('su_media_caption_link')->get(0)->getValue();
+    $link_url = $value['uri'];
+
+    $title = NULL;
+    try {
+      $url = Url::fromUri($link_url);
+      if ($url->isRouted()) {
+        // The only routed urls the link field supports is to nodes.
+        $parameters = $url->getRouteParameters();
+        $node = \Drupal::entityTypeManager()
+          ->getStorage('node')
+          ->load($parameters['node']);
+        $title = $node ? $node->label() : NULL;
+      }
+
+      // Absolute external url, fetch the contents of the page and grab the
+      // `<title>` value
+      if ($url->isExternal()) {
+        $page = file_get_contents($url->toString());
+        $title = preg_match('/<title[^>]*>(.*?)<\/title>/ims', $page, $match) ? $match[1] : NULL;
+      }
+
+      // If no title is found above, use the last part of the url as a sensible
+      // default to try an establish an human readable title.
+      if (!$title) {
+        $title = substr($url->toString(), strrpos($url->toString(), '/') + 1);
+        $title = ucwords(preg_replace('/[^\da-z]/i', ' ', $title));
+
+        // If STILL no title, throw an error to trigger the logger in the catch.
+        if (!$title) {
+          throw new \Exception('Trigger log');
+        }
+      }
+    } catch (\Exception $e) {
+      \Drupal::logger('stanford_profile_helper')
+        ->error('Unable to set link title for paragraph %id with url %url', [
+          '%id' => $paragraph->id(),
+          '%url' => $link_url,
+        ]);
+      continue;
+    }
+
+    if ($title) {
+      $value['title'] = $title;
+      $paragraph->set('su_media_caption_link', [$value])->save();
+    }
+  }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update hook to update media caption paragraphs with a link title.
- I did a query and there's at most 16 paragraphs to update per site. and that site is amptesting, so I don't believe batching the update is necessary.

# Need Review By (Date)
- 7/8

# Urgency
- medium

# Steps to Test
1. Follow the steps in https://github.com/SU-SWS/stanford_profile/pull/423

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
