### PR TITLE
D8CORE-4690 Modify mathjax filter plugin to fix media and spacing issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
         "drupal/ds": "~3.3",
         "drupal/field_formatter_class": "^1.3",
         "drupal/field_group": "^3.0@rc",
+        "drupal/mathjax": "^2.7",
         "drupal/paragraphs": "^1.11",
         "drupal/pdb": "^1.0@alpha",
         "drupal/ui_patterns": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "drupal/ds": "~3.3",
         "drupal/field_formatter_class": "^1.3",
         "drupal/field_group": "^3.0@rc",
-        "drupal/mathjax": "^2.7",
+        "drupal/mathjax": "^3.0",
         "drupal/paragraphs": "^1.11",
         "drupal/pdb": "^1.0@alpha",
         "drupal/ui_patterns": "~1.0",

--- a/src/Plugin/Filter/Mathjax.php
+++ b/src/Plugin/Filter/Mathjax.php
@@ -46,7 +46,7 @@ class Mathjax extends MathjaxFilter implements ContainerFactoryPluginInterface {
   public function process($text, $langcode) {
     $result = new FilterProcessResult($text);
     $config_type = $this->config->get('config_type');
-    if ($config_type == 0 && preg_match('/((\$\$.*\$\$)|(\\\(.*\\\))|(\\\[.*\\\]))/', $text )) {
+    if ($config_type == 0 && preg_match('/((\$\$.*\$\$)|(\\\(.*\\\))|(\\\[.*\\\]))/', $text)) {
       $result->setAttachments(['library' => ['mathjax/source']]);
     }
     return $result;

--- a/src/Plugin/Filter/Mathjax.php
+++ b/src/Plugin/Filter/Mathjax.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\stanford_profile_helper\Plugin\Filter;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\filter\FilterProcessResult;
+use Drupal\mathjax\Plugin\Filter\MathjaxFilter;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Overrides the Mathjax filter to prevent an unwanted div from the markup.
+ */
+class Mathjax extends MathjaxFilter implements ContainerFactoryPluginInterface {
+
+  /**
+   * Mathajax settings config.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->config = $config_factory->get('mathjax.settings');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process($text, $langcode) {
+    $result = new FilterProcessResult($text);
+    $config_type = $this->config->get('config_type');
+    if ($config_type == 0 && preg_match('/((\$\$.*\$\$)|(\\\(.*\\\))|(\\\[.*\\\]))/', $text )) {
+      $result->setAttachments(['library' => ['mathjax/source']]);
+    }
+    return $result;
+  }
+
+}

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -31,6 +31,15 @@ use Drupal\taxonomy_menu\Plugin\Menu\TaxonomyMenuMenuLink;
 use Drupal\user\RoleInterface;
 
 /**
+ * Implements hook_filter_info_alter().
+ */
+function stanford_profile_helper_filter_info_alter(&$info) {
+  if (isset($info['filter_mathjax'])) {
+    $info['filter_mathjax']['class'] = 'Drupal\stanford_profile_helper\Plugin\Filter\Mathjax';
+  }
+}
+
+/**
  * Implements hook_theme().
  */
 function stanford_profile_helper_theme($existing, $type, $theme, $path) {

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -34,7 +34,10 @@ use Drupal\user\RoleInterface;
  * Implements hook_filter_info_alter().
  */
 function stanford_profile_helper_filter_info_alter(&$info) {
-  if (isset($info['filter_mathjax'])) {
+  if (
+    isset($info['filter_mathjax']) &&
+    \Drupal::moduleHandler()->moduleExists('mathjax')
+  ) {
     $info['filter_mathjax']['class'] = 'Drupal\stanford_profile_helper\Plugin\Filter\Mathjax';
   }
 }

--- a/tests/src/Unit/Plugin/Filter/MathjaxTest.php
+++ b/tests/src/Unit/Plugin/Filter/MathjaxTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\Tests\stanford_profile_helper\Unit\Plugin\Filter;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\stanford_profile_helper\Plugin\Filter\Mathjax;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Class MathjaxTest.
+ *
+ * @coversDefaultClass \Drupal\stanford_profile_helper\Plugin\Filter\Mathjax
+ */
+class MathjaxTest extends UnitTestCase {
+
+  /**
+   * The filter shouldn't create extra divs.
+   */
+  public function testMathjaxFilter() {
+    $container = new ContainerBuilder();
+    $configs = ['mathjax.settings' => ['config_type' => 0]];
+    $container->set('config.factory', $this->getConfigFactoryStub($configs));
+    $mathjax = Mathjax::create($container, [], '', ['provider' => 'stanford_profile_helper']);
+    $text = '<div>FooBar</div>';
+    $processed = $mathjax->process($text, 'en');
+    $this->assertEquals($text, (string) $processed);
+    $this->assertEmpty($processed->getAttachments());
+
+    $text = '<div>Foo \(a \ne 0\) Bar</div>';
+    $processed = $mathjax->process($text, 'en');
+    $this->assertEquals($text, (string) $processed);
+    $this->assertNotEmpty($processed->getAttachments());
+
+    $text = '<div>Foo \[a \ne 0\] Bar</div>';
+    $processed = $mathjax->process($text, 'en');
+    $this->assertEquals($text, (string) $processed);
+    $this->assertNotEmpty($processed->getAttachments());
+
+    $text = '<div>Foo $$a \ne 0$$ Bar</div>';
+    $processed = $mathjax->process($text, 'en');
+    $this->assertEquals($text, (string) $processed);
+    $this->assertNotEmpty($processed->getAttachments());
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Replace the mathjax text filter to remove the wrapping div that's not necessary and only add the external js when math formula is present
- Fixes wysiwyg media issues and spacing because of the additional wrapping div.

# Need Review By (Date)
- 8/12

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. clear all caches
3. fill out a wysiwyg with some math formula like `$$x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$`
4. verify when you save the formula is still displayed

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
