### PR TITLE
Added check to make sure field exists before adding constraint

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -920,8 +920,10 @@ function stanford_profile_helper_field_widget_form_alter(&$element, FormStateInt
  */
 function stanford_profile_helper_entity_bundle_field_info_alter(&$fields, EntityTypeInterface $entity_type, $bundle) {
 
-  if ($bundle === 'stanford_global_message'
-      && !is_null($fields['su_global_msg_enabled'])) {
+  if (
+    $bundle == 'stanford_global_message' &&
+    !empty($fields['su_global_msg_enabled'])
+  ) {
     $fields['su_global_msg_enabled']->addConstraint('global_message_constraint', []);
   }
 

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -920,7 +920,8 @@ function stanford_profile_helper_field_widget_form_alter(&$element, FormStateInt
  */
 function stanford_profile_helper_entity_bundle_field_info_alter(&$fields, EntityTypeInterface $entity_type, $bundle) {
 
-  if ($bundle === 'stanford_global_message') {
+  if ($bundle === 'stanford_global_message'
+      && !is_null($fields['su_global_msg_enabled'])) {
     $fields['su_global_msg_enabled']->addConstraint('global_message_constraint', []);
   }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Under some circumstances, the `stanford_profile_helper` module was applying a constraint on the global message field before it was created during automated testing.  This was causing codeception tests to fail in `engineering_profile` since it was erroring out before installation was complete.  This PR corrects the problem by checking to make sure the field isn't NULL before attempting to apply the constraint.  No new functionality is introduced. 

# Review By (Date)
- before next release

# Criticality
- 2, since it only affects tests and then not always.

# Urgency
- low

# Review Tasks

## Setup tasks and/or behavior to test

1. Take a look at the small change.
2. Verify tests pass.

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? No.

