### PR TITLE
D8CORE-4793 Configure mathjax to only target equations in <p> tags

### DIFF
--- a/js/stanford_profile_helper.mathjax.js
+++ b/js/stanford_profile_helper.mathjax.js
@@ -1,0 +1,9 @@
+// Mathjax configuration settings.
+// @see https://docs.mathjax.org/en/latest/options/startup/startup.html
+window.MathJax = {
+  startup: {
+    elements: [
+      'p'
+    ]
+  }
+}

--- a/stanford_profile_helper.libraries.yml
+++ b/stanford_profile_helper.libraries.yml
@@ -1,0 +1,4 @@
+mathjax:
+  version: VERSION
+  js:
+    js/stanford_profile_helper.mathjax.js: {}

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -58,7 +58,8 @@ function stanford_profile_helper_theme($existing, $type, $theme, $path) {
  */
 function stanford_profile_helper_library_info_alter(&$libraries, $extension) {
   if ($extension == 'mathjax') {
-    unset($libraries['setup']);
+    $libraries['source']['dependencies'][] = 'stanford_profile_helper/mathjax';
+    unset($libraries['setup'], $libraries['config']);
   }
 }
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Configure mathjax so that formulas can't be placed in <p> tags.

# Need Review By (Date)
- 9/30

# Urgency
- high

# Steps to Test
1. checkout this branch and clear caches
2. create a page and put this formula in the page title and in the body. `\(ax^2 + bx + c = 0\)`
3. after saving verify the formula in the page header is still raw text, but the one in the body was converted to the formula.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
