### PR TITLE
Ignore home, 404, and 403 pages from indexing

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -26,9 +26,27 @@ use Drupal\layout_builder\SectionComponent;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\node\NodeForm;
 use Drupal\node\NodeInterface;
+use Drupal\search_api\IndexInterface;
 use Drupal\taxonomy\TermInterface;
 use Drupal\taxonomy_menu\Plugin\Menu\TaxonomyMenuMenuLink;
 use Drupal\user\RoleInterface;
+
+/**
+ * Implements hook_search_api_index_items_alter().
+ */
+function stanford_profile_helper_search_api_index_items_alter(IndexInterface $index, array &$items) {
+  $exclude_pages = \Drupal::config('system.site')->get('page');
+  // Remove the 404, 403, and home page from indexing for search results.
+  /** @var \Drupal\search_api\Item\Item $item */
+  foreach ($items as $item_id => $item) {
+    $entity = $item->getOriginalObject()->getValue();
+    if ($entity instanceof NodeInterface) {
+      if (in_array('/node/' . $entity->id(), $exclude_pages)) {
+        unset($items[$item_id]);
+      }
+    }
+  }
+}
 
 /**
  * Implements hook_page_attachments().


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Exclude the home page, 404 and 403 pages from being indexed by search api.

# Need Review By (Date)
- :shrug: 

# Urgency
- low

# Steps to Test
1. checkout this branch
2. clear caches
3. `drush sapi-c; drush sapi-i` to clear search indexing and re-index
4. search on the site for `found`
5. verify the "Page not found" is not a result.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
