### PR TITLE
D8CORE-4246 unset stanford_basic FA library if the FA module exists

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -94,6 +94,14 @@ function stanford_profile_helper_library_info_alter(&$libraries, $extension) {
     $libraries['source']['dependencies'][] = 'stanford_profile_helper/mathjax';
     unset($libraries['setup'], $libraries['config']);
   }
+
+  // Rely on the fontawesome module to provide the library.
+  if (
+    $extension == 'stanford_basic' &&
+    \Drupal::moduleHandler()->moduleExists('fontawesome')
+  ) {
+    unset($libraries['fontawesome']);
+  }
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- related to https://github.com/SU-SWS/stanford_profile/pull/464
- Remove the Stanford Basic FA library if the FA module exists

# Need Review By (Date)
- 11/19

# Urgency
- low

# Steps to Test
1. follow steps in https://github.com/SU-SWS/stanford_profile/pull/464
2. checkout this branch.
3. View any page
4. inspect the page and verify you only see 1 source coming from the font awesome library, not two different versions.
5. ie you should not see something like this: 
![image](https://user-images.githubusercontent.com/7185045/141205943-3cb665ed-01cc-457f-83ff-f69500a03201.png)


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
