### PR TITLE
Modify the imported redirects to point at the node instead of the alias

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -46,6 +46,26 @@ function stanford_profile_helper_form_taxonomy_overview_terms_alter(&$form, Form
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function stanford_profile_helper_redirect_presave(EntityInterface $redirect) {
+  $destination = $redirect->get('redirect_redirect')->getString();
+
+  // If a redirect is added to go to the aliased path of a node (often from
+  // importing redirect), change the destination to target the node instead.
+  // This works if the destination is `/about` or `/node/9`.
+  if (preg_match('/^internal:(\/.*)/', $destination, $matches)) {
+    // Find the internal path from the alias.
+    $path = \Drupal::service('path_alias.manager')->getPathByAlias($matches[1]);
+
+    // Grab the node id from the internal path and use that as the destination.
+    if (preg_match('/node\/(\d+)/', $path, $matches)) {
+      $redirect->set('redirect_redirect', 'entity:node/' . $matches[1]);
+    }
+  }
+}
+
+/**
  * Implements hook_search_api_index_items_alter().
  */
 function stanford_profile_helper_search_api_index_items_alter(IndexInterface $index, array &$items) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When importing a list of redirect, the destination might be `/about` but it is saved in that way in the database. It's saved like `internal:/about`. Ideally it would target the node itself if there is one. This will convert the alias to the internal path that targets the entity.

# Need Review By (Date)
- 1/20

# Urgency
- medium

# Steps to Test
1. checkout this branch and clear caches
2. create a csv for redirects like:
```
From,To
/foo-bar,/research
```
3. Import the csv on `/admin/config/search/redirect/import`
4. edit the newly created redirect
5. validate it is tied to the node and not just the alias.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
