### PR TITLE
Purge the source url when a redirect is saved

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -63,6 +63,42 @@ function stanford_profile_helper_redirect_presave(EntityInterface $redirect) {
       $redirect->set('redirect_redirect', 'entity:node/' . $matches[1]);
     }
   }
+
+  // Purge everything for the source url so that it can redirect without any
+  // intervention.
+  if (\Drupal::moduleHandler()->moduleExists('purge_processor_lateruntime')) {
+    $source = $redirect->get('redirect_source')->getString();
+    _stanford_profile_helper_purge_path($source);
+  }
+}
+
+/**
+ * Purges a relative path using the generated absolute url.
+ *
+ * @param string $path
+ *   Drupal site relative path.
+ *
+ * @throws \Drupal\purge\Plugin\Purge\Invalidation\Exception\InvalidExpressionException
+ * @throws \Drupal\purge\Plugin\Purge\Invalidation\Exception\MissingExpressionException
+ * @throws \Drupal\purge\Plugin\Purge\Invalidation\Exception\TypeUnsupportedException
+ */
+function _stanford_profile_helper_purge_path($path) {
+  $url = Url::fromUserInput('/' . trim($path, '/'), ['absolute' => TRUE])
+    ->toString();
+
+  $purgeInvalidationFactory = \Drupal::service('purge.invalidation.factory');
+  $purgeProcessors = \Drupal::service('purge.processors');
+  $purgePurgers = \Drupal::service('purge.purgers');
+
+  $processor = $purgeProcessors->get('lateruntime');
+  $invalidations = [$purgeInvalidationFactory->get('url', $url)];
+
+  try {
+    $purgePurgers->invalidate($processor, $invalidations);
+  }
+  catch (\Exception $e) {
+    \Drupal::logger('stanford_profile_helper')->error($e->getMessage());
+  }
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Purge the source url when a redirect is saved.
- Currently if a user visits a url that doesn't exists Varnish will cache the 404 response. This is good in 99.9% of scenarios. But when a user creates a redirect for the 404 page, varnish cache needs to be cleared so the redirect can take action.

# Need Review By (Date)
- 1/29

# Urgency
- medium

# Steps to Test
1. Visit or curl a url on the prod or test environment that will generate a 404 reponse. Curl is the fastest. `curl -I https://amptesting-test.sites.stanford.edu/[enter-some-url]`. Do this twice for the same url (to establish the age)
2. verify the response code is 404 and the age is > 0
3. log into the site and create a redirect for that url you used.
4. curl again, and verify the age > 0 and the response code is 404.
5. Follow the same steps on the dev environment with this branch (Check with me if you wish to do this step)

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
