### PR TITLE
D8CORE-5574 D8CORE-5575 D8CORE-5576 Adjustments to the schedule module form displays

### DIFF
--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -286,6 +286,12 @@ function stanford_profile_helper_form_alter(&$form, FormStateInterface $form_sta
       $status_element['#states'] = [
         'disabled' => [':input[name="publish_on[0][value][time]"]' => ['filled' => TRUE]],
       ];
+      $help_text = [
+        t('Select a date and time to publish this content in the future.'),
+        t('After scheduling the publish, it will automatically publish to your site after the selected time.'),
+        t('<em>For example, if you select 8:00am as the publish time, the content will be published between 8am-10am (<strong>estimated</strong>).</em>'),
+      ];
+      $form['publish_on']['widget'][0]['value']['#description'] = implode(' ', $help_text);
     }
   }
   if (strpos($form_id, 'views_form_') === 0) {

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -278,7 +278,15 @@ function _stanford_profile_helper_get_publications_layout() {
  */
 function stanford_profile_helper_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if ($form_state->getFormObject() instanceof NodeForm) {
-    unset($form['actions']['unlock']);
+    unset($form['actions']['unlock'], $form['scheduler_settings']);
+    if (!empty($form['publish_on'])) {
+      $form['publish_on']['#group'] = 'revision_information';
+      $form['publish_on']['#weight'] = -100;
+      $status_element = &$form['status']['widget']['value'];
+      $status_element['#states'] = [
+        'disabled' => [':input[name="publish_on[0][value][time]"]' => ['filled' => TRUE]],
+      ];
+    }
   }
   if (strpos($form_id, 'views_form_') === 0) {
     // Remove the select all since it selects every node, not just the ones
@@ -883,6 +891,15 @@ function stanford_profile_helper_field_widget_form_alter(&$element, FormStateInt
       $element['value']['#description'] = t($new_desc, $args);
     }
   }
+}
+
+/**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ */
+function stanford_profile_helper_field_widget_datetime_timestamp_no_default_form_alter(&$element, FormStateInterface $form_state, $context) {
+  // Set the date increment for scheduler settings.
+  $state = \Drupal::state();
+  $element['value']['#date_increment'] = $state->get('stanford_profile_helper.scheduler_increment', 60 * 60 * 4);
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Move the schedule publisher field into the "publish information" group
- Added help text to the scheduler field.
- Adjust the increment of the schedule field to 4 hours, but allow custom site override
- Disable the "Publish" checkbox if the schedule publish field is filled.

# Need Review By (Date)
- 3/16

# Urgency
- medium

# Steps to Test
1. checkout this branch
2. clear caches
3. verify the 3 above when creating/editing a piece of content.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
