### PR TITLE
Enable minimally branded theme for easier switching

### DIFF
--- a/stanford_profile_helper.install
+++ b/stanford_profile_helper.install
@@ -39,3 +39,10 @@ function stanford_profile_helper_update_8192() {
 function stanford_profile_helper_update_8193() {
   \Drupal::service('module_installer')->install(['views_custom_cache_tag']);
 }
+
+/**
+ * Enable minimally_branded_subtheme theme.
+ */
+function stanford_profile_helper_update_8194() {
+  \Drupal::service('theme_installer')->install(['minimally_branded_subtheme']);
+}

--- a/stanford_profile_helper.install
+++ b/stanford_profile_helper.install
@@ -41,8 +41,9 @@ function stanford_profile_helper_update_8193() {
 }
 
 /**
- * Enable minimally_branded_subtheme theme.
+ * Enable minimally_branded_subtheme theme & 2 modules.
  */
 function stanford_profile_helper_update_8194() {
   \Drupal::service('theme_installer')->install(['minimally_branded_subtheme']);
+  \Drupal::service('module_installer')->install(['views_custom_cache_tag', 'ctools_views']);
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update hook to enable the minimally branded theme. Avoids the need for devs to enable it via drush.

# Need Review By (Date)
- 3/17

# Urgency
- high

# Steps to Test
1. follow steps in https://github.com/SU-SWS/stanford_profile/pull/508

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
