### PR TITLE
Drush command to easily set up intranets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,6 +93,9 @@
         "su-sws/stanford_image_styles": "dev-8.x-1.x",
         "su-sws/stanford_text_editor": "dev-8.x-1.x"
     },
+    "require-dev": {
+        "drupal/externalauth": "^1.0 || ^2.0"
+    },
     "autoload": {
         "psr-4": {
             "Drupal\\stanford_profile_helper\\": "src/",

--- a/modules/stanford_intranet/drush.services.yml
+++ b/modules/stanford_intranet/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  stanford_intranet.commands:
+    class: \Drupal\stanford_intranet\Commands\IntranetCommands
+    arguments: ['@entity_type.manager', '@state', '@externalauth.authmap', '@password_generator']
+    tags:
+      - { name: drush.command }

--- a/modules/stanford_intranet/src/Commands/IntranetCommands.php
+++ b/modules/stanford_intranet/src/Commands/IntranetCommands.php
@@ -43,12 +43,16 @@ class IntranetCommands extends DrushCommands {
   protected $passwordGenerator;
 
   /**
-   * Commands constructor.
+   * Drush command constructor
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity Type Manager Service.
    * @param \Drupal\Core\State\StateInterface $state
    *   State service.
+   * @param \Drupal\externalauth\AuthmapInterface $authmap
+   *   External Authentication map service.
+   * @param \Drupal\Core\Password\PasswordGeneratorInterface $password_generator
+   *   Core password generator service.
    */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, StateInterface $state, AuthmapInterface $authmap, PasswordGeneratorInterface $password_generator) {
     $this->entityTypeManager = $entity_type_manager;
@@ -111,7 +115,7 @@ class IntranetCommands extends DrushCommands {
 
     // Restrict login access to specific affiliations.
     if (!empty($options['affiliations'])) {
-      $config_page->set('su_simplesaml_affil', explode(',', $options['affiliations']));
+      $config_page->set('su_simplesaml_affil', array_unique(explode(',', $options['affiliations'])));
     }
     // Restrict login access to specific workgroups..
     if (!empty($options['workgroups'])) {
@@ -129,7 +133,7 @@ class IntranetCommands extends DrushCommands {
     // If there are specific login restrictions, but there are also users that
     // were created, make sure they are added to the allowed list to login.
     if ((!empty($options['affiliations']) || !empty($options['workgroups'])) && !empty($options['users'])) {
-      $config_page->set('su_simplesaml_users', explode(',', $options['users']));
+      $config_page->set('su_simplesaml_users', array_unique(explode(',', $options['users'])));
     }
 
     $config_page->save();
@@ -215,7 +219,7 @@ class IntranetCommands extends DrushCommands {
         ->load($role_name);
 
       // If no role was found by the ID, let's try to find it using the label.
-      // ex: 'Site Manager'
+      // ex: 'Site Manager'.
       if (!$role) {
         $roles = $this->entityTypeManager->getStorage('user_role')
           ->loadByProperties(['label' => $role_name]);
@@ -235,7 +239,7 @@ class IntranetCommands extends DrushCommands {
     // The field widget uses pipe delimited values, same as the
     // simplesamlphp_auth module. So implode the array of role mappings into a
     // string.
-    return implode("|", $values);
+    return implode("|", array_unique($values));
   }
 
 }

--- a/modules/stanford_intranet/src/Commands/IntranetCommands.php
+++ b/modules/stanford_intranet/src/Commands/IntranetCommands.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Drupal\stanford_intranet\Commands;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Password\PasswordGeneratorInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\externalauth\AuthmapInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Stanford Intranet Drush commands.
+ */
+class IntranetCommands extends DrushCommands {
+
+  /**
+   * Entity Type Manager Service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * State service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * External Authentication map service.
+   *
+   * @var \Drupal\externalauth\AuthmapInterface
+   */
+  protected $authmap;
+
+  /**
+   * Core password generator service.
+   *
+   * @var \Drupal\Core\Password\PasswordGeneratorInterface
+   */
+  protected $passwordGenerator;
+
+  /**
+   * Commands constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity Type Manager Service.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   State service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, StateInterface $state, AuthmapInterface $authmap, PasswordGeneratorInterface $password_generator) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->state = $state;
+    $this->authmap = $authmap;
+    $this->passwordGenerator = $password_generator;
+  }
+
+  /**
+   * Enable and configure the intranet.
+   *
+   * @command stanford-intranet:setup
+   * @option roles
+   *   Comma delimited list of new roles to create
+   * @option affiliations
+   *   Comma delimited list of affiliations to limit login restrictions.
+   * @option users
+   *   Comma delimited list of SunetIDs to create users from.
+   * @option workgroups
+   *   Comma delimited list of workgroup to limit login access
+   * @option role-mapping
+   *   Comma delimited list of role mappings in the form `workgroup=role_name`
+   * @usage stanford-intranet:setup --roles='Site Group' --workgroups=foo:bar --role-mapping='Foo Bar=site_manager'
+   */
+  public function setupIntranet($options = [
+    'roles' => '',
+    'affiliations' => '',
+    'users' => '',
+    'workgroups' => '',
+    'role-mapping' => '',
+  ]) {
+    // Create the users and roles first in case we need to reference the roles
+    // later.
+    if (!empty($options['users'])) {
+      $this->createUsers(explode(',', $options['users']));
+    }
+    if (!empty($options['roles'])) {
+      $this->createRoles(explode(',', $options['roles']));
+    }
+
+    // Enable the intranet and clear caches. Clearing the cache tag will
+    // invalidate the Varnish layer if necessary. Then clearing all the cache
+    // bins to apply config overrides.
+    $this->state->set('stanford_intranet', 1);
+    Cache::invalidateTags(['config.system.site']);
+    foreach (Cache::getBins() as $cache_backend) {
+      $cache_backend->deleteAll();
+    }
+
+    $config_page_storage = $this->entityTypeManager->getStorage('config_pages');
+    /** @var \Drupal\config_pages\ConfigPagesInterface $config_page */
+    $config_page = $config_page_storage->load('stanford_saml');
+    // If the config page doesn't exist, we'll create it.
+    if (!$config_page) {
+      $config_page = $config_page_storage->create([
+        'type' => 'stanford_saml',
+        'context' => 'a:0:{}',
+      ]);
+    }
+
+    // Restrict login access to specific affiliations.
+    if (!empty($options['affiliations'])) {
+      $config_page->set('su_simplesaml_affil', explode(',', $options['affiliations']));
+    }
+    // Restrict login access to specific workgroups..
+    if (!empty($options['workgroups'])) {
+      $options['workgroups'] = explode(',', $options['workgroups']);
+      // Ensure `uit:sws` is the first in the list.
+      array_unshift($options['workgroups'], 'uit:sws');
+      $config_page->set('su_simplesaml_allowed', array_unique($options['workgroups']));
+    }
+
+    // Apply any desired role mapping.
+    if (!empty($options['role-mapping'])) {
+      $config_page->set('su_simplesaml_roles', $this->getRoleMappingValues(explode(',', $options['role-mapping'])));
+    }
+
+    // If there are specific login restrictions, but there are also users that
+    // were created, make sure they are added to the allowed list to login.
+    if ((!empty($options['affiliations']) || !empty($options['workgroups'])) && !empty($options['users'])) {
+      $config_page->set('su_simplesaml_users', explode(',', $options['users']));
+    }
+
+    $config_page->save();
+  }
+
+  /**
+   * Create users and register them with the external authentication.
+   *
+   * @param string[] $sunets
+   *   Array of SunetsIDs.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function createUsers(array $sunets) {
+    $user_storage = $this->entityTypeManager->getStorage('user');
+    foreach ($sunets as $sunet) {
+      // If a user already exists, print a message and move along.
+      if ($user_storage->loadByProperties(['name' => $sunet])) {
+        $this->output()
+          ->write(sprintf('User already exists with the name %s.', $sunet), TRUE);
+        continue;
+      }
+      $new_user = $user_storage->create([
+        'name' => $sunet,
+        'pass' => $this->passwordGenerator->generate(15),
+        'mail' => "$sunet@stanford.edu",
+        'roles' => ['site_manager'],
+        'status' => 1,
+      ]);
+      $new_user->save();
+      $this->authmap->save($new_user, 'simplesamlphp_auth', $sunet);
+    }
+  }
+
+  /**
+   * Create any custom roles for the site.
+   *
+   * @param string[] $roles
+   *   Array of role labels.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function createRoles(array $roles) {
+    $role_storage = $this->entityTypeManager->getStorage('user_role');
+    foreach ($roles as $role_name) {
+      $machine_name = preg_replace('/[^a-z0-9_]/', '_', strtolower($role_name));
+      if ($role_storage->load("custm_$machine_name")) {
+        $this->output()
+          ->write(sprintf('Role already exists with the name %s.', $role_name), TRUE);
+        continue;
+      }
+      $role_storage->create([
+        'id' => "custm_$machine_name",
+        'label' => $role_name,
+      ])->save();
+    }
+  }
+
+  /**
+   * Build the pipe delimited string from the given mappings for the field.
+   *
+   * @param string[] $mappings
+   *   Array of workgroup=role_name strings.
+   *
+   * @return string
+   *   Pipe delimited list of role mappings.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getRoleMappingValues(array $mappings): string {
+    // Always make sure uit:sws is mapped.
+    $values = ['administrator:eduPersonEntitlement,=,uit:sws'];
+
+    foreach ($mappings as $mapping) {
+      [$workgroup, $role_name] = explode('=', $mapping);
+      // First look up the role by the id, ex: site_manager.
+      $role = $this->entityTypeManager->getStorage('user_role')
+        ->load($role_name);
+
+      // If no role was found by the ID, let's try to find it using the label.
+      // ex: 'Site Manager'
+      if (!$role) {
+        $roles = $this->entityTypeManager->getStorage('user_role')
+          ->loadByProperties(['label' => $role_name]);
+        // There should only be 1 role with a given name, so let's use that one.
+        $role = !empty($roles) ? reset($roles) : NULL;
+      }
+
+      // No role was found by the ID or label. Print a message and continue to
+      // the next role mapping.
+      if (!$role) {
+        $this->output()
+          ->write(sprintf('No role found with the name %s.', $role_name), TRUE);
+        continue;
+      }
+      $values[] = $role->id() . ":eduPersonEntitlement,=,$workgroup";
+    }
+    // The field widget uses pipe delimited values, same as the
+    // simplesamlphp_auth module. So implode the array of role mappings into a
+    // string.
+    return implode("|", $values);
+  }
+
+}

--- a/modules/stanford_intranet/src/Commands/IntranetCommands.php
+++ b/modules/stanford_intranet/src/Commands/IntranetCommands.php
@@ -43,7 +43,7 @@ class IntranetCommands extends DrushCommands {
   protected $passwordGenerator;
 
   /**
-   * Drush command constructor
+   * Drush command constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity Type Manager Service.

--- a/modules/stanford_intranet/tests/src/Kernel/Commands/IntranetCommandsTest.php
+++ b/modules/stanford_intranet/tests/src/Kernel/Commands/IntranetCommandsTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Drupal\Tests\stanford_intranet\Kernel\Commands;
+
+use Drupal\config_pages\Entity\ConfigPages;
+use Drupal\config_pages\Entity\ConfigPagesType;
+use Drupal\externalauth\AuthmapInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\stanford_intranet\Commands\IntranetCommands;
+use Drupal\Tests\stanford_intranet\Kernel\IntranetKernelTestBase;
+
+/**
+ * Drush commands tests.
+ *
+ * @coversDefaultClass \Drupal\stanford_intranet\Commands\IntranetCommands
+ */
+class IntranetCommandsTest extends IntranetKernelTestBase {
+
+  /**
+   * Drush commands.
+   *
+   * @var \Drupal\stanford_intranet\Commands\IntranetCommands
+   */
+  protected $commands;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('config_pages');
+    ConfigPagesType::create([
+      'id' => 'stanford_saml',
+      'context' => [],
+      'menu' => [],
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'su_simplesaml_affil',
+      'type' => 'list_string',
+      'entity_type' => 'config_pages',
+      'cardinality' => -1
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'su_simplesaml_affil',
+      'entity_type' => 'config_pages',
+      'bundle' => 'stanford_saml',
+
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'su_simplesaml_users',
+      'type' => 'string',
+      'entity_type' => 'config_pages',
+      'cardinality' => -1
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'su_simplesaml_users',
+      'entity_type' => 'config_pages',
+      'bundle' => 'stanford_saml',
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'su_simplesaml_allowed',
+      'type' => 'string',
+      'entity_type' => 'config_pages',
+      'cardinality' => -1
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'su_simplesaml_allowed',
+      'entity_type' => 'config_pages',
+      'bundle' => 'stanford_saml',
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'su_simplesaml_roles',
+      'type' => 'string_long',
+      'entity_type' => 'config_pages',
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'su_simplesaml_roles',
+      'entity_type' => 'config_pages',
+      'bundle' => 'stanford_saml',
+    ])->save();
+
+    $ext_auth = $this->createMock(AuthmapInterface::class);
+    $this->commands = new IntranetCommands(\Drupal::entityTypeManager(), \Drupal::state(), $ext_auth, \Drupal::service('password_generator'));
+  }
+
+  public function testIntranetSetup() {
+    $options = [
+      'users' => 'Foo,Foo',
+      'roles' => 'Bar,Bar',
+      'affiliations' => 'staff,faculty',
+      'workgroups' => 'foo:bar,bar:foo',
+      'role-mapping' => 'foo:bar=Bar,bar=Baz',
+    ];
+    $this->commands->setupIntranet($options);
+    $this->assertTrue((bool) \Drupal::state()->get('stanford_intranet'));
+
+    $this->assertNotEmpty(\Drupal::entityTypeManager()
+      ->getStorage('user')
+      ->loadByProperties(['name' => 'Foo']));
+
+    $this->assertNotEmpty(\Drupal::entityTypeManager()
+      ->getStorage('user_role')
+      ->loadByProperties(['label' => 'Bar']));
+
+    /** @var \Drupal\config_pages\ConfigPagesInterface $config_page */
+    $config_page = ConfigPages::load('stanford_saml');
+
+    $affil = $config_page->get('su_simplesaml_affil')->getString();
+    $this->assertStringContainsString('staff', $affil);
+    $this->assertStringContainsString('faculty', $affil);
+
+    $allowed_users = $config_page->get('su_simplesaml_users')->getString();
+    $this->assertEquals('Foo', $allowed_users);
+
+    $allowed_users = $config_page->get('su_simplesaml_users')->getString();
+    $this->assertEquals('Foo', $allowed_users);
+  }
+
+}

--- a/modules/stanford_intranet/tests/src/Kernel/IntranetKernelTestBase.php
+++ b/modules/stanford_intranet/tests/src/Kernel/IntranetKernelTestBase.php
@@ -24,6 +24,7 @@ abstract class IntranetKernelTestBase extends KernelTestBase {
     'user',
     'config_pages',
     'stanford_profile_helper',
+    'options',
   ];
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Drush command to enable intranet and do all the config pages work for us from CLI.
- Unfortunately it needs to be deployed to the server to use, so we can't use it until after the next release.

# Need Review By (Date)
- :shrug: 

# Urgency
- low

# Steps to Test
1. checkout this branch.
2. clear caches
3. run `drush stanford-intranet:setup --help`
4. view the options and the way to use the command.
5. run the command
6. verify any options you configured get applied and visible on the `/admin/config/people/simplesaml` config page.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
