### PR TITLE
Update hook and drush command to move all public files into private file system.

### DIFF
--- a/modules/stanford_intranet/drush.services.yml
+++ b/modules/stanford_intranet/drush.services.yml
@@ -1,6 +1,6 @@
 services:
   stanford_intranet.commands:
     class: \Drupal\stanford_intranet\Commands\IntranetCommands
-    arguments: ['@entity_type.manager', '@state', '@externalauth.authmap', '@password_generator']
+    arguments: ['@entity_type.manager', '@state', '@externalauth.authmap', '@password_generator', '@stanford_intranet.manager'']
     tags:
       - { name: drush.command }

--- a/modules/stanford_intranet/drush.services.yml
+++ b/modules/stanford_intranet/drush.services.yml
@@ -1,6 +1,6 @@
 services:
   stanford_intranet.commands:
     class: \Drupal\stanford_intranet\Commands\IntranetCommands
-    arguments: ['@entity_type.manager', '@state', '@externalauth.authmap', '@password_generator', '@stanford_intranet.manager'']
+    arguments: ['@entity_type.manager', '@state', '@externalauth.authmap', '@password_generator', '@stanford_intranet.manager']
     tags:
       - { name: drush.command }

--- a/modules/stanford_intranet/src/Commands/IntranetCommands.php
+++ b/modules/stanford_intranet/src/Commands/IntranetCommands.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Password\PasswordGeneratorInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\externalauth\AuthmapInterface;
+use Drupal\stanford_intranet\StanfordIntranetManagerInterface;
 use Drush\Commands\DrushCommands;
 
 /**
@@ -43,6 +44,13 @@ class IntranetCommands extends DrushCommands {
   protected $passwordGenerator;
 
   /**
+   * Intranet manager service.
+   *
+   * @var \Drupal\stanford_intranet\StanfordIntranetManagerInterface
+   */
+  protected $intranetManager;
+
+  /**
    * Drush command constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -53,12 +61,24 @@ class IntranetCommands extends DrushCommands {
    *   External Authentication map service.
    * @param \Drupal\Core\Password\PasswordGeneratorInterface $password_generator
    *   Core password generator service.
+   * @param \Drupal\stanford_intranet\StanfordIntranetManagerInterface $intranet_manager
+   *   Intranet manager service.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, StateInterface $state, AuthmapInterface $authmap, PasswordGeneratorInterface $password_generator) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, StateInterface $state, AuthmapInterface $authmap, PasswordGeneratorInterface $password_generator, StanfordIntranetManagerInterface $intranet_manager) {
     $this->entityTypeManager = $entity_type_manager;
     $this->state = $state;
     $this->authmap = $authmap;
     $this->passwordGenerator = $password_generator;
+    $this->intranetManager = $intranet_manager;
+  }
+
+  /**
+   * Move files from public to the private file system.
+   *
+   * @command stanford-intranet:move-files
+   */
+  public function moveIntranetFiles(){
+    $this->intranetManager->moveIntranetFiles();
   }
 
   /**
@@ -101,6 +121,7 @@ class IntranetCommands extends DrushCommands {
     foreach (Cache::getBins() as $cache_backend) {
       $cache_backend->deleteAll();
     }
+    $this->moveIntranetFiles();
 
     $config_page_storage = $this->entityTypeManager->getStorage('config_pages');
     /** @var \Drupal\config_pages\ConfigPagesInterface $config_page */

--- a/modules/stanford_intranet/src/Commands/IntranetCommands.php
+++ b/modules/stanford_intranet/src/Commands/IntranetCommands.php
@@ -77,7 +77,7 @@ class IntranetCommands extends DrushCommands {
    *
    * @command stanford-intranet:move-files
    */
-  public function moveIntranetFiles(){
+  public function moveIntranetFiles() {
     $this->intranetManager->moveIntranetFiles();
   }
 

--- a/modules/stanford_intranet/src/StanfordIntranetManager.php
+++ b/modules/stanford_intranet/src/StanfordIntranetManager.php
@@ -84,7 +84,8 @@ class StanfordIntranetManager implements StanfordIntranetManagerInterface {
       $this->fileRepository->move($file, str_replace('public://', 'private://', $uri));
     }
 
-    $image_styles = $this->entityTypeManager->getStorage('image_style')->loadMultiple();
+    $image_styles = $this->entityTypeManager->getStorage('image_style')
+      ->loadMultiple();
     foreach ($image_styles as $style) {
       $style->flush();
     }

--- a/modules/stanford_intranet/src/StanfordIntranetManager.php
+++ b/modules/stanford_intranet/src/StanfordIntranetManager.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Drupal\stanford_intranet;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\file\FileRepositoryInterface;
+
+/**
+ * Intranet manager service class.
+ */
+class StanfordIntranetManager implements StanfordIntranetManagerInterface {
+
+  /**
+   * Entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * File repository service.
+   *
+   * @var \Drupal\file\FileRepositoryInterface
+   */
+  protected $fileRepository;
+
+  /**
+   * File system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * State service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * Service constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager service.
+   * @param \Drupal\file\FileRepositoryInterface $file_repository
+   *   File repository service.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   File system service.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   State service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, FileRepositoryInterface $file_repository, FileSystemInterface $file_system, StateInterface $state) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->fileRepository = $file_repository;
+    $this->fileSystem = $file_system;
+    $this->state = $state;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function moveIntranetFiles(): void {
+    if (!$this->state->get('stanford_intranet')) {
+      return;
+    }
+    $storage = $this->entityTypeManager->getStorage('file');
+    $fids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('uri', 'public://%', 'LIKE')
+      ->execute();
+
+    foreach ($fids as $fid) {
+      /** @var \Drupal\file\FileInterface $file */
+      $file = $storage->load($fid);
+
+      $uri = $file->getFileUri();
+      $new_uri = str_replace('public://', 'private://', $uri);
+      $directory = dirname($new_uri);
+
+      $this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
+      $this->fileRepository->move($file, str_replace('public://', 'private://', $uri));
+    }
+  }
+
+}

--- a/modules/stanford_intranet/src/StanfordIntranetManager.php
+++ b/modules/stanford_intranet/src/StanfordIntranetManager.php
@@ -83,6 +83,11 @@ class StanfordIntranetManager implements StanfordIntranetManagerInterface {
       $this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
       $this->fileRepository->move($file, str_replace('public://', 'private://', $uri));
     }
+
+    $image_styles = $this->entityTypeManager->getStorage('image_style')->loadMultiple();
+    foreach ($image_styles as $style) {
+      $style->flush();
+    }
   }
 
 }

--- a/modules/stanford_intranet/src/StanfordIntranetManagerInterface.php
+++ b/modules/stanford_intranet/src/StanfordIntranetManagerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\stanford_intranet;
+
+/**
+ * Intranet manager service interface.
+ */
+interface StanfordIntranetManagerInterface {
+
+  /**
+   * Move public files into the private file system.
+   */
+  public function moveIntranetFiles(): void;
+
+}

--- a/modules/stanford_intranet/stanford_intranet.install
+++ b/modules/stanford_intranet/stanford_intranet.install
@@ -5,7 +5,6 @@
  * stanford_intranet.install
  */
 
-use Drupal\Core\File\FileSystemInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\node\Entity\NodeType;

--- a/modules/stanford_intranet/stanford_intranet.install
+++ b/modules/stanford_intranet/stanford_intranet.install
@@ -54,8 +54,5 @@ function stanford_intranet_uninstall() {
  * Move files to private storage if the intranet is enabled.
  */
 function stanford_intranet_update_8001() {
-  $kernel = \Drupal::service('kernel');
-  $kernel->invalidateContainer();
-  $kernel->rebuildContainer();
   \Drupal::service('stanford_intranet.manager')->moveIntranetFiles();
 }

--- a/modules/stanford_intranet/stanford_intranet.install
+++ b/modules/stanford_intranet/stanford_intranet.install
@@ -5,6 +5,7 @@
  * stanford_intranet.install
  */
 
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\node\Entity\NodeType;
@@ -47,4 +48,35 @@ function stanford_intranet_uninstall() {
   \Drupal::state()->delete('stanford_intranet');
   \Drupal::state()->delete('stanford_intranet.rids');
   \Drupal::state()->delete('stanford_intranet.allow_file_uploads');
+}
+
+/**
+ * Move files to private storage if the intranet is enabled.
+ */
+function stanford_intranet_update_8001() {
+  if (!\Drupal::state()->get('stanford_intranet', FALSE)) {
+    return;
+  }
+
+  $storage = \Drupal::entityTypeManager()->getStorage('file');
+  $fids = $storage->getQuery()
+    ->accessCheck(FALSE)
+    ->condition('uri', 'public://%', 'LIKE')
+    ->execute();
+
+  /** @var \Drupal\file\FileRepository $file_repo */
+  $file_repo = \Drupal::service('file.repository');
+  /** @var \Drupal\Core\File\FileSystem $file_system */
+  $file_system = \Drupal::service('file_system');
+  foreach ($fids as $fid) {
+    /** @var \Drupal\file\FileInterface $file */
+    $file = $storage->load($fid);
+
+    $uri = $file->getFileUri();
+    $new_uri = str_replace('public://', 'private://', $uri);
+    $directory = dirname($new_uri);
+
+    $file_system->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
+    $file_repo->move($file, str_replace('public://', 'private://', $uri));
+  }
 }

--- a/modules/stanford_intranet/stanford_intranet.install
+++ b/modules/stanford_intranet/stanford_intranet.install
@@ -54,29 +54,8 @@ function stanford_intranet_uninstall() {
  * Move files to private storage if the intranet is enabled.
  */
 function stanford_intranet_update_8001() {
-  if (!\Drupal::state()->get('stanford_intranet', FALSE)) {
-    return;
-  }
-
-  $storage = \Drupal::entityTypeManager()->getStorage('file');
-  $fids = $storage->getQuery()
-    ->accessCheck(FALSE)
-    ->condition('uri', 'public://%', 'LIKE')
-    ->execute();
-
-  /** @var \Drupal\file\FileRepository $file_repo */
-  $file_repo = \Drupal::service('file.repository');
-  /** @var \Drupal\Core\File\FileSystem $file_system */
-  $file_system = \Drupal::service('file_system');
-  foreach ($fids as $fid) {
-    /** @var \Drupal\file\FileInterface $file */
-    $file = $storage->load($fid);
-
-    $uri = $file->getFileUri();
-    $new_uri = str_replace('public://', 'private://', $uri);
-    $directory = dirname($new_uri);
-
-    $file_system->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
-    $file_repo->move($file, str_replace('public://', 'private://', $uri));
-  }
+  $kernel = \Drupal::service('kernel');
+  $kernel->invalidateContainer();
+  $kernel->rebuildContainer();
+  \Drupal::service('stanford_intranet.manager')->moveIntranetFiles();
 }

--- a/modules/stanford_intranet/stanford_intranet.services.yml
+++ b/modules/stanford_intranet/stanford_intranet.services.yml
@@ -4,3 +4,6 @@ services:
     tags:
       - {name: config.factory.override, priority: 300}
     arguments: ['@config.factory', '@state']
+  stanford_intranet.manager:
+    class: \Drupal\stanford_intranet\StanfordIntranetManager
+    arguments: ['@entity_type.manager', '@file.repository', '@file_system', '@state']

--- a/modules/stanford_intranet/tests/src/Kernel/Commands/IntranetCommandsTest.php
+++ b/modules/stanford_intranet/tests/src/Kernel/Commands/IntranetCommandsTest.php
@@ -85,7 +85,7 @@ class IntranetCommandsTest extends IntranetKernelTestBase {
     ])->save();
 
     $ext_auth = $this->createMock(AuthmapInterface::class);
-    $this->commands = new IntranetCommands(\Drupal::entityTypeManager(), \Drupal::state(), $ext_auth, \Drupal::service('password_generator'));
+    $this->commands = new IntranetCommands(\Drupal::entityTypeManager(), \Drupal::state(), $ext_auth, \Drupal::service('password_generator'), \Drupal::service('stanford_intranet.manager'));
   }
 
   public function testIntranetSetup() {

--- a/modules/stanford_intranet/tests/src/Kernel/IntranetKernelTestBase.php
+++ b/modules/stanford_intranet/tests/src/Kernel/IntranetKernelTestBase.php
@@ -25,6 +25,7 @@ abstract class IntranetKernelTestBase extends KernelTestBase {
     'config_pages',
     'stanford_profile_helper',
     'options',
+    'image',
   ];
 
   /**
@@ -34,9 +35,12 @@ abstract class IntranetKernelTestBase extends KernelTestBase {
     parent::setUp();
     $this->installEntitySchema('node');
     $this->installEntitySchema('user');
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('image_style');
     $this->installConfig('system');
     $this->installSchema('system', ['sequences']);
     $this->installSchema('node', ['node_access']);
+    $this->installSchema('file', ['file_usage']);
 
     $this->fieldStorage = FieldStorageConfig::create([
       'field_name' => 'field_foo',

--- a/modules/stanford_intranet/tests/src/Kernel/StanfordIntranetManagerTest.php
+++ b/modules/stanford_intranet/tests/src/Kernel/StanfordIntranetManagerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\Tests\stanford_intranet\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\file\Entity\File;
+use Drupal\file\FileInterface;
+use Drupal\image\Entity\ImageStyle;
+
+/**
+ * Test intranet manager service.
+ *
+ * @coversDefaultClass \Drupal\stanford_intranet\StanfordIntranetManager
+ * @group stanford_intranet
+ */
+class StanfordIntranetManagerTest extends IntranetKernelTestBase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->setSetting('file_private_path', $this->container->getParameter('site.path') . '/private');
+    mkdir($this->container->getParameter('site.path') . '/private', 0777, TRUE);
+
+    ImageStyle::create(['name' => 'foo', 'label' => 'foo'])->save();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) {
+    parent::register($container);
+    $container->register('stream_wrapper.private', 'Drupal\Core\StreamWrapper\PrivateStream')
+      ->addTag('stream_wrapper', ['scheme' => 'private']);
+  }
+
+  /**
+   * Service moves the public files.
+   */
+  public function testFileMoves() {
+    $path = 'public://testfile.txt';
+    file_put_contents($path, 'Foo Bar');
+
+    $file = File::create([
+      'uri' => $path,
+      'filename' => 'testfile.txt',
+      'status' => FileInterface::STATUS_PERMANENT,
+    ]);
+    $file->save();
+
+    \Drupal::service('stanford_intranet.manager')->moveIntranetFiles();
+    $moved_file = File::load($file->id());
+    $this->assertEquals($path, $moved_file->getFileUri());
+
+    \Drupal::state()->set('stanford_intranet', 1);
+    \Drupal::service('stanford_intranet.manager')->moveIntranetFiles();
+    $moved_file = File::load($file->id());
+    $this->assertEquals('private://testfile.txt', $moved_file->getFileUri());
+  }
+
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Update hook and drush commands to move all public files into private directories.

# Need Review By (Date)
- asap

# Urgency
- high

# Steps to Test
1. checkout this branch
2. enable intranet `drush sset stanford_intranet 1`
3. run database updates `drush updb` or `drush stanford-intranet:move-files` to run just the file movements
4. view any media and validate the file/image exists in the private directory.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
