### PR TITLE
Fixup white bar above footer

### DIFF
--- a/modules/stanford_intranet/lib/scss/base/intranet.scss
+++ b/modules/stanford_intranet/lib/scss/base/intranet.scss
@@ -8,9 +8,9 @@
   }
 }
 
-
 .page-content {
   background-color: $su-color-fog;
+  flex-grow: 1;
 }
 
 div {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Getting rid of the white bar that appears between the page-content and footer at some screen sizes.
![Screen Shot 2023-05-10 at 2 51 25 PM](https://github.com/SU-SWS/stanford_profile_helper/assets/49299083/bc4adb90-2b0c-4575-affe-af3f3300c626)

# Review By (Date)
- When convenient

# Criticality
- High

# Urgency
- High

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to an intranet site (e.g. https://cabinet.stanford.edu/roster) and confirm the white bar between the page-content and local footer is no longer appearing.

# Associated Issues and/or People
- https://stanfordwebservices.slack.com/archives/C02D5MQUS3A/p1683752914604879
