### PR TITLE
D8CORE-6824: Spacer paragraph - changed label of default value

### DIFF
--- a/modules/stanford_layout_paragraphs/stanford_layout_paragraphs.module
+++ b/modules/stanford_layout_paragraphs/stanford_layout_paragraphs.module
@@ -101,7 +101,7 @@ function stanford_layout_paragraphs_paragraphs_behavior_info_alter(&$paragraphs_
  */
 function stanford_layout_paragraphs_form_layout_paragraphs_component_form_alter(&$form, &$form_state) {
   // Modify the labels on the Spacer paragraph select list.
-  if (!empty($form['su_spacer_size'])){
+  if (!empty($form['su_spacer_size'])) {
     $form['su_spacer_size']['widget']['#options']['_none'] = 'Standard';
   }
 }

--- a/modules/stanford_layout_paragraphs/stanford_layout_paragraphs.module
+++ b/modules/stanford_layout_paragraphs/stanford_layout_paragraphs.module
@@ -95,4 +95,3 @@ function _stanford_layout_paragraphs_is_editing_layout_paragraphs() {
 function stanford_layout_paragraphs_paragraphs_behavior_info_alter(&$paragraphs_behavior) {
   $paragraphs_behavior['layout_paragraphs']['class'] = 'Drupal\stanford_layout_paragraphs\Plugin\paragraphs\Behavior\LayoutParagraphs';
 }
-

--- a/modules/stanford_layout_paragraphs/stanford_layout_paragraphs.module
+++ b/modules/stanford_layout_paragraphs/stanford_layout_paragraphs.module
@@ -96,12 +96,3 @@ function stanford_layout_paragraphs_paragraphs_behavior_info_alter(&$paragraphs_
   $paragraphs_behavior['layout_paragraphs']['class'] = 'Drupal\stanford_layout_paragraphs\Plugin\paragraphs\Behavior\LayoutParagraphs';
 }
 
-/**
- * Implements hook_form_layout_paragraphs_component_form_alter().
- */
-function stanford_layout_paragraphs_form_layout_paragraphs_component_form_alter(&$form, &$form_state) {
-  // Modify the labels on the Spacer paragraph select list.
-  if (!empty($form['su_spacer_size'])) {
-    $form['su_spacer_size']['widget']['#options']['_none'] = 'Standard';
-  }
-}

--- a/modules/stanford_layout_paragraphs/stanford_layout_paragraphs.module
+++ b/modules/stanford_layout_paragraphs/stanford_layout_paragraphs.module
@@ -95,3 +95,13 @@ function _stanford_layout_paragraphs_is_editing_layout_paragraphs() {
 function stanford_layout_paragraphs_paragraphs_behavior_info_alter(&$paragraphs_behavior) {
   $paragraphs_behavior['layout_paragraphs']['class'] = 'Drupal\stanford_layout_paragraphs\Plugin\paragraphs\Behavior\LayoutParagraphs';
 }
+
+/**
+ * Implements hook_form_layout_paragraphs_component_form_alter().
+ */
+function stanford_layout_paragraphs_form_layout_paragraphs_component_form_alter(&$form, &$form_state) {
+  // Modify the labels on the Spacer paragraph select list.
+  if (!empty($form['su_spacer_size'])){
+    $form['su_spacer_size']['widget']['#options']['_none'] = 'Standard';
+  }
+}

--- a/src/EventSubscriber/FormEventSubscriber.php
+++ b/src/EventSubscriber/FormEventSubscriber.php
@@ -55,6 +55,12 @@ class FormEventSubscriber implements EventSubscriberInterface {
       $form['widget']['value']['#default_value'] = (bool) $this->state->get('nobots');
     }
 
+    // Change the default value label in the Spacer paragraph.
+    if ($items->getFieldDefinition()->getName() == 'su_spacer_size') {
+      $form = &$event->getWidgetCompleteForm();
+      $form['widget']['#options']['_none'] = 'Standard';
+    }
+
     // Hide token help in the viewfield widget.
     if ($context['widget']->getPluginId() == 'viewfield_select') {
       $widget_form = &$event->getWidgetCompleteForm();

--- a/stanford_profile_helper.info.yml
+++ b/stanford_profile_helper.info.yml
@@ -17,6 +17,7 @@ dependencies:
   - drupal:help
   - drupal:media
   - drupal:media_library
+  - drupal:views
   - hook_event_dispatcher:core_event_dispatcher
   - hook_event_dispatcher:field_event_dispatcher
   - hook_event_dispatcher:preprocess_event_dispatcher

--- a/tests/src/Kernel/EventSubscriber/FormEventSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/FormEventSubscriberTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\stanford_profile_helper\Kernel\EventSubscriber;
 
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Form\FormState;
 use Drupal\stanford_profile_helper\EventSubscriber\FormEventSubscriber;
 use Drupal\taxonomy\Entity\Term;
@@ -9,10 +10,10 @@ use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\stanford_profile_helper\Kernel\SuProfileHelperKernelTestBase;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\paragraphs\Entity\ParagraphsType;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\EntityFormBuilderInterface;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field_event_dispatcher\Event\Field\WidgetCompleteFormAlterEvent;
+use Drupal\field_event_dispatcher\FieldHookEvents;
 
 /**
  * Test the event subscriber.
@@ -21,11 +22,17 @@ use Drupal\field\Entity\FieldStorageConfig;
  */
 class FormEventSubscriberTest extends SuProfileHelperKernelTestBase {
 
+  /**
+   * A mock paragraph type.
+   *
+   * @var \Drupal\paragraphs\Entity\ParagraphsType
+   */
   protected $paragraphType;
+
   /**
    * {@inheritDoc}
    */
-  protected function setUp():void {
+  protected function setUp(): void {
     parent::setUp();
     $this->installEntitySchema('paragraph');
     $this->installSchema('file', ['file_usage']);
@@ -34,63 +41,96 @@ class FormEventSubscriberTest extends SuProfileHelperKernelTestBase {
   /**
    * Term form contains an arg helper field.
    */
-    public function testTaxonomyFormAlter() {
-      Vocabulary::create(['vid' => 'foobar', 'label' => 'Foo'])->save();
-      $term = Term::create(['vid' => 'foobar', 'name' => 'foo bar & baz -bin _']);
-      $term->save();
-      $form = \Drupal::service('entity.form_builder')->getForm($term, 'default');
-      $this->assertEquals('foobarbazbin', $form['name']['arg_helper']['#default_value']);
+  public function testTaxonomyFormAlter() {
+    Vocabulary::create(['vid' => 'foobar', 'label' => 'Foo'])->save();
+    $term = Term::create(['vid' => 'foobar', 'name' => 'foo bar & baz -bin _']);
+    $term->save();
+    $form = \Drupal::service('entity.form_builder')->getForm($term, 'default');
+    $this->assertEquals('foobarbazbin', $form['name']['arg_helper']['#default_value']);
 
-      $form_state = new FormState();
-      $form_state->setValue(['name', 0, 'value'], 'bar_baz &$ bin foo');
-      FormEventSubscriber::argHelperAjaxCallback($form, $form_state);
-      $this->assertEquals('barbazbinfoo', $form['name']['arg_helper']['#value']);
-    }
+    $form_state = new FormState();
+    $form_state->setValue(['name', 0, 'value'], 'bar_baz &$ bin foo');
+    FormEventSubscriber::argHelperAjaxCallback($form, $form_state);
+    $this->assertEquals('barbazbinfoo', $form['name']['arg_helper']['#value']);
+  }
 
-    /**
-     * Test the label on the spacer paragraph.
-     */
-    public function testFieldWidgetFormAlter() {
+  /**
+   * Test the label on the spacer paragraph.
+   */
+  public function testFieldWidgetFormAlter() {
+    $this->paragraphType = ParagraphsType::create([
+      'id' => 'stanford_spacer',
+      'label' => 'Mock Spacer',
+    ])->save();
 
-      $this->paragraphType = ParagraphsType::create([
-        'id' => 'stanford_spacer',
-        'label' => 'Mock Spacer',
-      ])->save();
-
-      $paragraph_field_storage = FieldStorageConfig::create([
-        'field_name' => 'su_spacer_size',
-        'entity_type' => 'paragraph',
-        'type' => 'list_string',
-        'cardinality' => 1,
-        'settings' => [
-          'allowed_values' => [
-            '_none' => '- None -',
-            'option_2' => 'Option 2 Label',
-          ],
+    $paragraph_field_storage = FieldStorageConfig::create([
+      'field_name' => 'su_spacer_size',
+      'entity_type' => 'paragraph',
+      'type' => 'list_string',
+      'cardinality' => 1,
+      'settings' => [
+        'allowed_values' => [
+          'option_1' => 'Option 1',
+          'option_2' => 'Option 2',
         ],
-      ])->save();
+      ],
+    ]);
+    $paragraph_field_storage->save();
 
-      //Maybe needs a cache clear?
-      $entity_type_manager = \Drupal::service('entity_type.manager');
-      $entity_type_manager->clearCachedDefinitions();
+    FieldConfig::create([
+      'field_storage' => $paragraph_field_storage,
+      'bundle' => 'stanford_spacer',
+      'settings' => [],
+    ])->save();
 
-      FieldConfig::create([
-        'field_storage' => $paragraph_field_storage,
-        'bundle' => 'stanford_spacer',
-        'settings' => [],
-      ])->save();
+    $form_display = EntityFormDisplay::create([
+      'targetEntityType' => 'paragraph',
+      'bundle' => 'stanford_spacer',
+      'mode' => 'default',
+      'status' => TRUE,
+    ]);
+    $form_display->setComponent('su_spacer_size', ['type' => 'options_select']);
+    $form_display->save();
 
-      $paragraph = Paragraph::create([
-        'type' => 'stanford_spacer',
-        'su_spacer_size' => '_none',
-      ]);
-      $paragraph->save();
+    $paragraph = Paragraph::create([
+      'type' => 'stanford_spacer',
+      'su_spacer_size' => '_none',
+    ]);
+    $paragraph->save();
 
-      $entity_form_builder = \Drupal::service('entity.form_builder');
-      $form_object = $entity_form_builder->getForm($paragraph, 'default');
+    $entity_form_builder = \Drupal::service('entity.form_builder');
+    // This creates the form array, but is not a form object.
+    $complete_form_array = $entity_form_builder->getForm($paragraph);
 
-      $field_widget_structure = $form_object['su_spacer_size'];
-      $this->assertEquals('Standard', $field_widget_structure['#options']['_none']);
-    }
+    // We do need the form object.
+    $form_object = $entity_type_manager->getFormObject($paragraph->getEntityTypeId(), 'default');
+    $form_object->setEntity($paragraph);
+
+    $field_item = $paragraph->get('su_spacer_size');
+
+    $form_state = new FormState();
+    $form_state->setFormObject($form_object);
+    $form_state->setCompleteForm($complete_form_array);
+
+    $spacer_form_element = $complete_form_array['su_spacer_size'];
+
+    $entity_form_display = EntityFormDisplay::collectRenderDisplay($form_state->getFormObject()->getEntity(), 'default');
+    $widget = $entity_form_display->getRenderer('su_spacer_size');
+
+    $context = [
+      'form' => $form_object,
+      'widget' => $widget,
+      'items' => $field_item,
+      'delta' => 0,
+      'default' => FALSE,
+    ];
+
+    // Trigger the event.
+    $event = new WidgetCompleteFormAlterEvent($spacer_form_element, $form_state, $context);
+    $event_dispatcher = \Drupal::service('event_dispatcher');
+    $event_dispatcher->dispatch($event, FieldHookEvents::WIDGET_COMPLETE_FORM_ALTER);
+
+    $this->assertEquals('Standard', $spacer_form_element['widget']['#options']['_none']);
+  }
 
 }

--- a/tests/src/Kernel/EventSubscriber/FormEventSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/FormEventSubscriberTest.php
@@ -7,6 +7,12 @@ use Drupal\stanford_profile_helper\EventSubscriber\FormEventSubscriber;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\Tests\stanford_profile_helper\Kernel\SuProfileHelperKernelTestBase;
+use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\paragraphs\Entity\ParagraphsType;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityFormBuilderInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 
 /**
  * Test the event subscriber.
@@ -14,6 +20,16 @@ use Drupal\Tests\stanford_profile_helper\Kernel\SuProfileHelperKernelTestBase;
  * @coversDefaultClass \Drupal\stanford_profile_helper\EventSubscriber\FormEventSubscriber
  */
 class FormEventSubscriberTest extends SuProfileHelperKernelTestBase {
+
+  protected $paragraphType;
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp():void {
+    parent::setUp();
+    $this->installEntitySchema('paragraph');
+    $this->installSchema('file', ['file_usage']);
+  }
 
   /**
    * Term form contains an arg helper field.
@@ -29,6 +45,56 @@ class FormEventSubscriberTest extends SuProfileHelperKernelTestBase {
       $form_state->setValue(['name', 0, 'value'], 'bar_baz &$ bin foo');
       FormEventSubscriber::argHelperAjaxCallback($form, $form_state);
       $this->assertEquals('barbazbinfoo', $form['name']['arg_helper']['#value']);
+    }
+
+    /**
+     * Test the label on the spacer paragraph.
+     */
+    public function testFieldWidgetFormAlter() {
+
+      $this->paragraphType = ParagraphsType::create([
+        'id' => 'stanford_spacer',
+        'label' => 'Mock Spacer',
+      ])->save();
+
+      $paragraph_field_storage = FieldStorageConfig::create([
+        'field_name' => 'su_spacer_size',
+        'entity_type' => 'paragraph',
+        'type' => 'list_string',
+        'cardinality' => 1,
+        'settings' => [
+          'allowed_values' => [
+            '_none' => '- None -',
+            'option_2' => 'Option 2 Label',
+          ],
+        ],
+      ])->save();
+
+      $entity_type_manager = \Drupal::service('entity_type.manager');
+      $entity_type_manager->clearCachedDefinitions();
+
+      echo(var_export($paragraph_field_storage, true));
+
+      FieldConfig::create([
+        'field_storage' => $paragraph_field_storage,
+        'bundle' => 'stanford_spacer',
+        'settings' => [],
+      ])->save();
+
+      $paragraph = Paragraph::create([
+        'type' => 'stanford_spacer',
+        'su_spacer_size' => '_none',
+      ]);
+      $paragraph->save();
+
+      $entity_form_builder = \Drupal::service('entity.form_builder');
+      $form_object = $entity_form_builder->getForm($paragraph, 'default');
+
+      echo(var_export(array_keys($form_object), true));
+      die();
+
+      $field_widget_structure = $form_object['su_spacer_size'];
+      $this->assertEquals('Standard', $field_widget_structure['#options']['_none']);
     }
 
 }

--- a/tests/src/Kernel/EventSubscriber/FormEventSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/FormEventSubscriberTest.php
@@ -98,7 +98,9 @@ class FormEventSubscriberTest extends SuProfileHelperKernelTestBase {
     ]);
     $paragraph->save();
 
+    $entity_type_manager = \Drupal::service('entity_type.manager');
     $entity_form_builder = \Drupal::service('entity.form_builder');
+
     // This creates the form array, but is not a form object.
     $complete_form_array = $entity_form_builder->getForm($paragraph);
 

--- a/tests/src/Kernel/EventSubscriber/FormEventSubscriberTest.php
+++ b/tests/src/Kernel/EventSubscriber/FormEventSubscriberTest.php
@@ -70,10 +70,9 @@ class FormEventSubscriberTest extends SuProfileHelperKernelTestBase {
         ],
       ])->save();
 
+      //Maybe needs a cache clear?
       $entity_type_manager = \Drupal::service('entity_type.manager');
       $entity_type_manager->clearCachedDefinitions();
-
-      echo(var_export($paragraph_field_storage, true));
 
       FieldConfig::create([
         'field_storage' => $paragraph_field_storage,
@@ -89,9 +88,6 @@ class FormEventSubscriberTest extends SuProfileHelperKernelTestBase {
 
       $entity_form_builder = \Drupal::service('entity.form_builder');
       $form_object = $entity_form_builder->getForm($paragraph, 'default');
-
-      echo(var_export(array_keys($form_object), true));
-      die();
 
       $field_widget_structure = $form_object['su_spacer_size'];
       $this->assertEquals('Standard', $field_widget_structure['#options']['_none']);

--- a/tests/src/Kernel/SuProfileHelperKernelTestBase.php
+++ b/tests/src/Kernel/SuProfileHelperKernelTestBase.php
@@ -33,15 +33,18 @@ abstract class SuProfileHelperKernelTestBase extends KernelTestBase {
     'rabbit_hole',
     'rh_node',
     'menu_link_content',
-    'link',
     'redirect',
     'text',
     'field',
+    'field_ui',
     'config_pages',
     'link',
     'taxonomy',
     'pathauto',
     'token',
+    'paragraphs',
+    'options',
+    'file',
   ];
 
   /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- We want to change the label of the `- None -` option on the Spacer paragraph to be `Standard`.

# Review By (Date)
- code freeze

# Criticality
- 2

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Check out the [corresponding branch in Stanford Profile](https://github.com/SU-SWS/stanford_profile/pull/700) to see the updated help text in the UI
3. Rebuild Cache and import config `drush cr ; drush ci`
4. Navigate to any Layout Builder page.
5. Create a Spacer paragraph wherever is convenient
6. Verify the default size option of the spacer is now `Standard`

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? No, but the help text is updated in Stanford Profile, and that one does

## Front End Validation
- [ ] Design is approved by @ user?
- [ ] HTML validation: Is the markup using the appropriate semantic tags and [passes validation](https://validator.w3.org/nu/)? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Cross-browser testing: Has been performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Automated accessibility: Scans performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Manual accessibility: Manually tested? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
