### PR TITLE
D8CORE-6715 Better hiding of list paragraph

### DIFF
--- a/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/ListParagraphBehavior.php
+++ b/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/ListParagraphBehavior.php
@@ -51,14 +51,16 @@ class ListParagraphBehavior extends ParagraphsBehaviorBase {
    * {@inheritDoc}
    */
   public function view(array &$build, ParagraphInterface $paragraph, EntityViewDisplayInterface $display, $view_mode) {
+
     if (!isset($build['su_list_view']) || !empty(Element::children($build['su_list_view']))) {
       return;
     }
-    if ($empty_message = $paragraph->getBehaviorSetting('list_paragraph', 'empty_message')) {
-      $build['su_list_view']['#markup'] = $empty_message;
-    }
+
+    // If there is no empty message set, it will be null.
+    $build['su_list_view']['#markup'] = $paragraph->getBehaviorSetting('list_paragraph', 'empty_message');
+
     if ($paragraph->getBehaviorSetting('list_paragraph', 'hide_empty')) {
-      // D8CORE-6715: If the list is empty, the paragraph is uneditable and orphaned
+      // D8CORE-6715: If the list is empty, the paragraph becomes uneditable.
       unset($build['su_list_button'], $build['su_list_description'], $build['su_list_headline'], $build['su_list_view']);
     }
   }

--- a/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/ListParagraphBehavior.php
+++ b/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/ListParagraphBehavior.php
@@ -51,13 +51,13 @@ class ListParagraphBehavior extends ParagraphsBehaviorBase {
    * {@inheritDoc}
    */
   public function view(array &$build, ParagraphInterface $paragraph, EntityViewDisplayInterface $display, $view_mode) {
-
     if (!isset($build['su_list_view']) || !empty(Element::children($build['su_list_view']))) {
       return;
     }
 
-    // If there is no empty message set, it will be null.
-    $build['su_list_view']['#markup'] = $paragraph->getBehaviorSetting('list_paragraph', 'empty_message');
+    if ($paragraph->getBehaviorSetting('list_paragraph', 'empty_message')) {
+      $build['su_list_view']['#markup'] = $paragraph->getBehaviorSetting('list_paragraph', 'empty_message');
+    }
 
     if ($paragraph->getBehaviorSetting('list_paragraph', 'hide_empty')) {
       // D8CORE-6715: If the list is empty, the paragraph becomes uneditable.

--- a/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/ListParagraphBehavior.php
+++ b/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/ListParagraphBehavior.php
@@ -58,8 +58,8 @@ class ListParagraphBehavior extends ParagraphsBehaviorBase {
       $build['su_list_view']['#markup'] = $empty_message;
     }
     if ($paragraph->getBehaviorSetting('list_paragraph', 'hide_empty')) {
-      // Unset everything, but keep the cache for any cache tags and keys.
-      $build = ['#cache' => $build['#cache']];
+      // D8CORE-6715: If the list is empty, the paragraph is uneditable and orphaned
+      unset($build['su_list_button'], $build['su_list_description'], $build['su_list_headline'], $build['su_list_view']);
     }
   }
 

--- a/modules/jumpstart_ui/tests/src/Unit/Plugin/paragraphs/Behavior/ListParagraphBehaviorTest.php
+++ b/modules/jumpstart_ui/tests/src/Unit/Plugin/paragraphs/Behavior/ListParagraphBehaviorTest.php
@@ -72,7 +72,13 @@ class ListParagraphBehaviorTest extends UnitTestCase {
     $plugin->view($build, $paragraph, $display, 'default');
     $this->assertEquals(['su_list_view' => [], '#cache' => []], $build);
 
-    $build = ['su_list_view' => [], '#cache' => []];
+    $build = [
+      'su_list_view' => [],
+      'su_list_button' => [],
+      'su_list_description' => [],
+      'su_list_headline' => [],
+      '#cache' => []
+    ];
     $this->paragraphBehavior['hide_empty'] = TRUE;
     $plugin->view($build, $paragraph, $display, 'default');
     $this->assertEquals(['#cache' => []], $build);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- If a user created a list paragraph which resulted in an empty list, and the `hide_empty` behavior was `TRUE`, the paragraph became inaccessible in editing interface, effectively orphaning it and making it uneditable.  This corrects that by being a little more selective about what gets unset.

# Review By (Date)
- before next code cutoff

# Criticality
- 2

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Clear caches
3. On any page, create a List paragraph, and choose whatever kind of list you want, as long as it will return nothing.  e.g., if there are no events in the calendar, try an events list.
4. In the Styles/Behaviors section of the list paragraph, click "Hide if empty".  Save the Paragraph.
5. Verify that you can still locate the list paragraph in the editing interface, and you can still get back into the paragraph and change things.
6. Verify that once the page is published, the list paragraph is not visible to the visitor.

### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? NO

## Front End Validation
- [ ] Design is approved by @ user?
- [ ] HTML validation: Is the markup using the appropriate semantic tags and [passes validation](https://validator.w3.org/nu/)? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Cross-browser testing: Has been performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Automated accessibility: Scans performed? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?
- [ ] Manual accessibility: Manually tested? Or, [QA request ticket created](https://github.com/SU-SWS/template_warehouse/blob/master/jira_templates/QA_request_template.txt)?

## Backend / Functional Validation
### Code
- [ ] Are the naming conventions following our standards?
- [ ] Does the code have sufficient inline comments?
- [ ] Is there anything in this code that would be hidden or hard to discover through the UI?
- [ ] Are there any [code smells](https://blog.codinghorror.com/code-smells/)?
- [ ] Are tests provided? eg (unit, behat, or codeception)

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ ] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [ ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)
