### PR TITLE
D8CORE-7211 D8CORE-7210 Add header behaviors for banner and card paragraphs

### DIFF
--- a/modules/jumpstart_ui/dist/templates/decanter/components/card/card.twig
+++ b/modules/jumpstart_ui/dist/templates/decanter/components/card/card.twig
@@ -136,7 +136,7 @@
     {# Card Headline #}
     {%- block block_card_headline  %}
       {%- if card_headline is not empty %}
-        <h2>
+        <{{ card_headline_tag|default('h2') }}{{ card_headline_attributes }}>
           {%- if card_allow_headline_link and allow_links -%}
             <a href="{{ card_link }}" {{ card_cta_attributes }}>
           {%- endif -%}
@@ -144,7 +144,7 @@
           {% if card_allow_headline_link and allow_links -%}
             </a>
           {%- endif -%}
-        </h2>
+        </{{ card_headline_tag|default('h2') }}>
       {% endif -%}
     {% endblock -%}
 

--- a/modules/jumpstart_ui/dist/templates/decanter/components/hero/hero.twig
+++ b/modules/jumpstart_ui/dist/templates/decanter/components/hero/hero.twig
@@ -68,6 +68,8 @@
         "card_button_label": hero_button_label,
         "card_cta_label": hero_cta_label,
         "card_cta_attributes": hero_cta_attributes,
+        "card_headline_tag": card_headline_tag,
+        "card_headline_attributes": card_headline_attributes
       }
       only
     %}

--- a/modules/jumpstart_ui/jumpstart_ui.module
+++ b/modules/jumpstart_ui/jumpstart_ui.module
@@ -10,6 +10,7 @@
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\paragraphs\ParagraphInterface;
 use Drupal\ui_patterns\Element\PatternContext;
 use Drupal\ui_patterns\UiPatterns;
 
@@ -149,4 +150,30 @@ function jumpstart_ui_preprocess_layout(&$variables) {
 function jumpstart_ui_preprocess_media(&$variables) {
   $variables['attributes']['class'][] = 'media-entity-wrapper';
   $variables['attributes']['class'][] = $variables['elements']['#media']->bundle();
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function jumpstart_ui_preprocess_pattern_hero(&$variables) {
+  /** @var \Drupal\ui_patterns\Element\PatternContext $context */
+  $context = $variables['context'];
+  $entity = $context->getProperty('entity');
+  if ($entity instanceof ParagraphInterface && $entity->bundle() == 'stanford_banner') {
+    $headline_attributes = new Attribute();
+
+    $header_behavior = $entity->getBehaviorSetting('hero_pattern', 'heading', 'h2');
+    preg_match('/^(\w+)(.*)$/', $header_behavior, $header_tag);
+    $variables['card_headline_tag'] = $header_tag[1];
+
+    if ($header_tag[2]) {
+      $headline_attributes->addClass(trim(str_replace('.', ' ', $header_tag[2])));
+    }
+
+    if ($entity->getBehaviorSetting('hero_pattern', 'hide_heading', FALSE)) {
+      $headline_attributes->addClass('visually-hidden');
+    }
+
+    $variables['card_headline_attributes'] = $headline_attributes;
+  }
 }

--- a/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/HeroPatternBehavior.php
+++ b/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/HeroPatternBehavior.php
@@ -20,6 +20,9 @@ use Drupal\paragraphs\ParagraphsTypeInterface;
  */
 class HeroPatternBehavior extends ParagraphsBehaviorBase {
 
+  /**
+   * {@inheritDoc}
+   */
   public function defaultConfiguration() {
     return [
       'overlay_position' => 'left',

--- a/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/HeroPatternBehavior.php
+++ b/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/HeroPatternBehavior.php
@@ -73,7 +73,7 @@ class HeroPatternBehavior extends ParagraphsBehaviorBase {
         'h2' => 'H2',
         'h3' => 'H3',
         'h4' => 'H4',
-        'div' => $this->t('Splash Text'),
+        'div.su-font-splash' => $this->t('Splash Text'),
       ],
       '#default_value' => $paragraph->getBehaviorSetting('hero_pattern', 'heading', 'h2'),
     ];

--- a/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/HeroPatternBehavior.php
+++ b/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/HeroPatternBehavior.php
@@ -14,10 +14,19 @@ use Drupal\paragraphs\ParagraphsTypeInterface;
  * @ParagraphsBehavior(
  *   id = "hero_pattern",
  *   label = @Translation("Hero Pattern"),
- *   description = @Translation("Display options for the hero pattern paragraph.")
+ *   description = @Translation("Display options for the hero pattern
+ *   paragraph.")
  * )
  */
 class HeroPatternBehavior extends ParagraphsBehaviorBase {
+
+  public function defaultConfiguration() {
+    return [
+      'overlay_position' => 'left',
+      'heading' => 'h2',
+      'hide_heading' => FALSE,
+    ];
+  }
 
   /**
    * {@inheritDoc}
@@ -54,6 +63,22 @@ class HeroPatternBehavior extends ParagraphsBehaviorBase {
    */
   public function buildBehaviorForm(ParagraphInterface $paragraph, array &$form, FormStateInterface $form_state) {
     $form = parent::buildBehaviorForm($paragraph, $form, $form_state);
+    $form['heading'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Heading Level'),
+      '#options' => [
+        'h2' => 'H2',
+        'h3' => 'H3',
+        'h4' => 'H4',
+        'div' => $this->t('Splash Text'),
+      ],
+      '#default_value' => $paragraph->getBehaviorSetting('hero_pattern', 'heading', 'h2'),
+    ];
+    $form['hide_heading'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Visually Hide Heading'),
+      '#default_value' => $paragraph->getBehaviorSetting('hero_pattern', 'hide_heading', FALSE),
+    ];
     $form['overlay_position'] = [
       '#type' => 'select',
       '#title' => $this->t('Text Overlay Position'),

--- a/modules/jumpstart_ui/templates/components/hero/hero.ui_patterns.yml
+++ b/modules/jumpstart_ui/templates/components/hero/hero.ui_patterns.yml
@@ -30,6 +30,11 @@ hero:
       label: "Headline"
       description: "The text headline"
       preview: "This is the headline"
+    hero_headline_tag:
+      type: text
+      label: "Headline Tag"
+      description: "Tag element for the headline"
+      preview: "h2"
     hero_body:
       type: text
       label: "Content"

--- a/modules/stanford_paragraph_card/src/Plugin/paragraphs/Behavior/CardBehavior.php
+++ b/modules/stanford_paragraph_card/src/Plugin/paragraphs/Behavior/CardBehavior.php
@@ -26,11 +26,35 @@ class CardBehavior extends ParagraphsBehaviorBase {
     return $paragraphs_type->id() == 'stanford_card';
   }
 
+  public function defaultConfiguration() {
+    return [
+      'heading' => 'h2',
+      'hide_heading' => false,
+      'link_style' => null,
+    ];
+  }
+
   /**
    * {@inheritDoc}
    */
   public function buildBehaviorForm(ParagraphInterface $paragraph, array &$form, FormStateInterface $form_state): array {
     $element = parent::buildBehaviorForm($paragraph, $form, $form_state);
+    $element['heading'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Heading Level'),
+      '#options' => [
+        'h2' => 'H2',
+        'h3' => 'H3',
+        'h4' => 'H4',
+        'div' => $this->t('Splash Text'),
+      ],
+      '#default_value' => $paragraph->getBehaviorSetting('su_card_styles', 'heading', 'h2'),
+    ];
+    $element['hide_heading'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Visually Hide Heading'),
+      '#default_value' => $paragraph->getBehaviorSetting('su_card_styles', 'hide_heading', FALSE),
+    ];
     $element['link_style'] = [
       '#title' => $this->t('Link Style'),
       '#description' => $this->t('Choose how you would like the link to display.'),

--- a/modules/stanford_paragraph_card/src/Plugin/paragraphs/Behavior/CardBehavior.php
+++ b/modules/stanford_paragraph_card/src/Plugin/paragraphs/Behavior/CardBehavior.php
@@ -49,7 +49,7 @@ class CardBehavior extends ParagraphsBehaviorBase {
         'h2' => 'H2',
         'h3' => 'H3',
         'h4' => 'H4',
-        'div' => $this->t('Splash Text'),
+        'div.su-font-splash' => $this->t('Splash Text'),
       ],
       '#default_value' => $paragraph->getBehaviorSetting('su_card_styles', 'heading', 'h2'),
     ];

--- a/modules/stanford_paragraph_card/src/Plugin/paragraphs/Behavior/CardBehavior.php
+++ b/modules/stanford_paragraph_card/src/Plugin/paragraphs/Behavior/CardBehavior.php
@@ -26,11 +26,14 @@ class CardBehavior extends ParagraphsBehaviorBase {
     return $paragraphs_type->id() == 'stanford_card';
   }
 
+  /**
+   * {@inheritDoc}
+   */
   public function defaultConfiguration() {
     return [
       'heading' => 'h2',
-      'hide_heading' => false,
-      'link_style' => null,
+      'hide_heading' => FALSE,
+      'link_style' => NULL,
     ];
   }
 
@@ -73,7 +76,7 @@ class CardBehavior extends ParagraphsBehaviorBase {
    */
   public function view(array &$build, ParagraphInterface $paragraph, EntityViewDisplayInterface $display, $view_mode): void {
     $link_style = $paragraph->getBehaviorSetting('su_card_styles', 'link_style');
-    if ($link_style ==  'action') {
+    if ($link_style == 'action') {
       // Change the DS config going in to the render.
       $build['#ds_configuration']['regions']['card_cta_label'] = $build['#ds_configuration']['regions']['card_button_label'];
       unset($build['#ds_configuration']['regions']['card_button_label']);

--- a/modules/stanford_paragraph_card/stanford_paragraph_card.module
+++ b/modules/stanford_paragraph_card/stanford_paragraph_card.module
@@ -5,6 +5,9 @@
  * stanford_paragraph_card.module
  */
 
+use Drupal\Core\Template\Attribute;
+use Drupal\paragraphs\ParagraphInterface;
+
 /**
  * Implements hook_preprocess_HOOK().
  */
@@ -62,5 +65,23 @@ function stanford_paragraph_card_preprocess_ds_entity_view(array &$variables) {
     // Unset the cruft.
     unset($variables['content']['#fields']['card_button_label']);
     unset($variables['content']['#ds_configuration']['regions']['card_button_label']);
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function stanford_paragraph_card_preprocess_pattern_card(&$variables) {
+  /** @var \Drupal\ui_patterns\Element\PatternContext $context */
+  $context = $variables['context'];
+  $entity = $context->getProperty('entity');
+
+  if ($entity instanceof ParagraphInterface && $entity->bundle() == 'stanford_card') {
+    $variables['card_headline_tag'] = $entity->getBehaviorSetting('su_card_styles', 'heading', 'h2');
+    $headline_attributes = new Attribute(['class' => ['headline']]);
+    if ($entity->getBehaviorSetting('su_card_styles', 'hide_heading', FALSE)) {
+      $headline_attributes->addClass('visually-hidden');
+    }
+    $variables['card_headline_attributes'] = $headline_attributes;
   }
 }

--- a/modules/stanford_paragraph_card/stanford_paragraph_card.module
+++ b/modules/stanford_paragraph_card/stanford_paragraph_card.module
@@ -77,11 +77,20 @@ function stanford_paragraph_card_preprocess_pattern_card(&$variables) {
   $entity = $context->getProperty('entity');
 
   if ($entity instanceof ParagraphInterface && $entity->bundle() == 'stanford_card') {
-    $variables['card_headline_tag'] = $entity->getBehaviorSetting('su_card_styles', 'heading', 'h2');
-    $headline_attributes = new Attribute(['class' => ['headline']]);
+    $headline_attributes = new Attribute();
+
+    $header_behavior = $entity->getBehaviorSetting('su_card_styles', 'heading', 'h2');
+    preg_match('/^(\w+)(.*)$/', $header_behavior, $header_tag);
+    $variables['card_headline_tag'] = $header_tag[1];
+
+    if ($header_tag[2]) {
+      $headline_attributes->addClass(trim(str_replace('.', ' ', $header_tag[2])));
+    }
+
     if ($entity->getBehaviorSetting('su_card_styles', 'hide_heading', FALSE)) {
       $headline_attributes->addClass('visually-hidden');
     }
+
     $variables['card_headline_attributes'] = $headline_attributes;
   }
 }

--- a/modules/stanford_profile_styles/dist/css/component/paragraph/card.css
+++ b/modules/stanford_profile_styles/dist/css/component/paragraph/card.css
@@ -1,0 +1,1 @@
+.su-card .su-card__contents h2{font-size:1.5625em;letter-spacing:-.012em}.su-card .su-card__contents h3{font-size:1.4em}.su-card .su-card__contents h4{font-size:1em}.su-card .su-card__contents .su-font-splash{font-size:1.4em}

--- a/modules/stanford_profile_styles/lib/scss/component/paragraph/card/_card.scss
+++ b/modules/stanford_profile_styles/lib/scss/component/paragraph/card/_card.scss
@@ -1,0 +1,21 @@
+@charset 'UTF-8';
+
+.su-card {
+  .su-card__contents {
+    h2 {
+      @include type-c;
+    }
+
+    h3 {
+      font-size: 1.4em;
+    }
+
+    h4 {
+      @include type-e;
+    }
+
+    .su-font-splash {
+      font-size: 1.4em;
+    }
+  }
+}

--- a/modules/stanford_profile_styles/lib/scss/component/paragraph/card/index.scss
+++ b/modules/stanford_profile_styles/lib/scss/component/paragraph/card/index.scss
@@ -1,0 +1,4 @@
+@charset 'UTF-8';
+@import
+'../../../config',
+'card';

--- a/modules/stanford_publication/tests/src/Kernel/Entity/CitationTest.php
+++ b/modules/stanford_publication/tests/src/Kernel/Entity/CitationTest.php
@@ -45,19 +45,19 @@ class CitationTest extends PublicationTestBase {
 
     // Nothing to link to.
     $biblio = $citation->getBibliography();
-    $expected = 'Doe, J. (2021). <i>Foo Bar</i> (5th ed.). Subtitle of Book. Awesome Publishing.';
+    $expected = 'Doe, J. (2021). <i>Foo Bar</i> (5th eds.). Subtitle of Book. Awesome Publishing.';
     $this->assertStringContainsString($expected, $biblio);
 
     // Links to the parent node.
     $citation->setParentEntity($this->parentNode, 'field_foo');
     $biblio = $citation->getBibliography();
-    $expected = 'Doe, J. (2021). <a href="/node/' . $this->parentNode->id() . '" hreflang="en"><i>Foo Bar</i></a> (5th ed.). Subtitle of Book. Awesome Publishing.';
+    $expected = 'Doe, J. (2021). <a href="/node/' . $this->parentNode->id() . '" hreflang="en"><i>Foo Bar</i></a> (5th eds.). Subtitle of Book. Awesome Publishing.';
     $this->assertStringContainsString($expected, $biblio);
 
     // Links to the url field.
     $citation->set('su_url', 'http://domain.org')->save();
     $biblio = $citation->getBibliography();
-    $expected = 'Doe, J. (2021). <a href="http://domain.org"><i>Foo Bar</i></a> (5th ed.). Subtitle of Book. Awesome Publishing.';
+    $expected = 'Doe, J. (2021). <a href="http://domain.org"><i>Foo Bar</i></a> (5th eds.). Subtitle of Book. Awesome Publishing.';
     $this->assertStringContainsString($expected, $biblio);
 
     // The DOI field does not get a link. The result should be the same as the

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -21,8 +21,10 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Serialization\Yaml;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Site\Settings;
+use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
+use Drupal\paragraphs\ParagraphInterface;
 use Drupal\search_api\IndexInterface;
 use Drupal\stanford_profile_helper\StanfordProfileHelper;
 use Drupal\taxonomy\TermInterface;
@@ -743,9 +745,9 @@ function stanford_profile_helper_preprocess_pattern_hero(&$variables) {
   /** @var \Drupal\ui_patterns\Element\PatternContext $context */
   $context = $variables['context'];
   $entity = $context->getProperty('entity');
-  if ($entity instanceof \Drupal\paragraphs\ParagraphInterface && $entity->bundle() == 'stanford_banner') {
+  if ($entity instanceof ParagraphInterface && $entity->bundle() == 'stanford_banner') {
     $variables['card_headline_tag'] = $entity->getBehaviorSetting('hero_pattern', 'heading', 'h2');
-    $headline_attributes = new \Drupal\Core\Template\Attribute(['class' => ['headline']]);
+    $headline_attributes = new Attribute(['class' => ['headline']]);
     if ($entity->getBehaviorSetting('hero_pattern', 'hide_heading', FALSE)) {
       $headline_attributes->addClass('visually-hidden');
     }

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -21,10 +21,8 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Serialization\Yaml;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Site\Settings;
-use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
-use Drupal\paragraphs\ParagraphInterface;
 use Drupal\search_api\IndexInterface;
 use Drupal\stanford_profile_helper\StanfordProfileHelper;
 use Drupal\taxonomy\TermInterface;
@@ -736,23 +734,6 @@ function stanford_profile_helper_preprocess_pattern_alert(&$variables) {
     }
   }
 
-}
-
-/**
- * Implements hook_preprocess_HOOK().
- */
-function stanford_profile_helper_preprocess_pattern_hero(&$variables) {
-  /** @var \Drupal\ui_patterns\Element\PatternContext $context */
-  $context = $variables['context'];
-  $entity = $context->getProperty('entity');
-  if ($entity instanceof ParagraphInterface && $entity->bundle() == 'stanford_banner') {
-    $variables['card_headline_tag'] = $entity->getBehaviorSetting('hero_pattern', 'heading', 'h2');
-    $headline_attributes = new Attribute(['class' => ['headline']]);
-    if ($entity->getBehaviorSetting('hero_pattern', 'hide_heading', FALSE)) {
-      $headline_attributes->addClass('visually-hidden');
-    }
-    $variables['card_headline_attributes'] = $headline_attributes;
-  }
 }
 
 /**

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -737,6 +737,23 @@ function stanford_profile_helper_preprocess_pattern_alert(&$variables) {
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ */
+function stanford_profile_helper_preprocess_pattern_hero(&$variables) {
+  /** @var \Drupal\ui_patterns\Element\PatternContext $context */
+  $context = $variables['context'];
+  $entity = $context->getProperty('entity');
+  if ($entity instanceof \Drupal\paragraphs\ParagraphInterface && $entity->bundle() == 'stanford_banner') {
+    $variables['card_headline_tag'] = $entity->getBehaviorSetting('hero_pattern', 'heading', 'h2');
+    $headline_attributes = new \Drupal\Core\Template\Attribute(['class' => ['headline']]);
+    if ($entity->getBehaviorSetting('hero_pattern', 'hide_heading', FALSE)) {
+      $headline_attributes->addClass('visually-hidden');
+    }
+    $variables['card_headline_attributes'] = $headline_attributes;
+  }
+}
+
+/**
  * Implements hook_preprocess_pattern_NAME().
  */
 function stanford_profile_helper_preprocess_pattern_localfooter(&$variables) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add header behaviors for card and banner paragraph types.

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Clear site caches
3. Create or edit a basic page.
4. add a card and banner
5. in the "Styles/behaviors" section, choose the desired heading level
6. save and observe the markup reflects your choice.
