### PR TITLE
D8CORE-7661: Filtered Lists in One Column Only

### DIFF
--- a/modules/stanford_layout_paragraphs/src/EventSubscriber/StanfordLayoutParagraphsSubscriber.php
+++ b/modules/stanford_layout_paragraphs/src/EventSubscriber/StanfordLayoutParagraphsSubscriber.php
@@ -55,7 +55,7 @@ class StanfordLayoutParagraphsSubscriber implements EventSubscriberInterface {
         ->getDefinition($layout_settings['layout'])->getRegions();
       if (count($layout_regions) > 1) {
         $types = $event->getTypes();
-        unset($types['stanford_banner'], $types['stanford_gallery'], $types['stanford_faq']);
+        unset($types['stanford_banner'], $types['stanford_gallery'], $types['stanford_faq']), $types['stanford_filtered_lists']);
         $event->setTypes($types);
       }
     }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This restricts the new filtered list PT to 1 column paragraphs

# Review By (Date)
- 5.6.0 code freeze

# Criticality
- Important!

# Urgency
- Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out the branch with the Filtered Lists PT (https://github.com/SU-SWS/stanford_profile/pull/894)
2. Set the version of Stanford Profile helper to this branch
3. Place a 1 column layout on a basic page and see if you can add a filtered list. Hopefully yes!
4. Place a 2 or 3 column layout on a basic page and see if you can add a filtered list. Hopefully no!


### Site Configuration Sync

- Is there a config:export in this PR that changes the config sync directory? NO

## Front End Validation
No front-end

## Backend / Functional Validation
### Code
N/A

### Code security
- [ ] Are all [forms properly sanitized](https://www.drupal.org/docs/8/security/drupal-8-sanitizing-output)?
- [ ] Any obvious [security flaws or new areas for attack](https://www.drupal.org/docs/8/security)?

## General
- [ NO] Is there anything included in this PR that is not related to the problem it is trying to solve?
- [YES ] Is the approach to the problem appropriate?

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)

# Resources
- [AMP Tool](https://stanford.levelaccess.net/index.php)
- [Accessibility Manual Test Script](https://docs.google.com/document/d/1ZXJ9RIUNXsS674ow9j3qJ2g1OAkCjmqMXl0Gs8XHEPQ/edit?usp=sharing)
- [HTML Validator](https://validator.w3.org/)
- [Browserstack](https://live.browserstack.com/dashboard) and link to [Browserstack Credentials](https://asconfluence.stanford.edu/confluence/display/SWS/External+Account+Credentials)