### PR TITLE
D8CORE-8227 | Rename title and _none option for layout selection

### DIFF
--- a/src/Hook/FormHooks.php
+++ b/src/Hook/FormHooks.php
@@ -138,9 +138,9 @@ class FormHooks {
     $items = $context['items'];
     $field_def = $items->getFieldDefinition();
     if ($field_def->getName() == 'layout_selection') {
-      $field_widget_complete_form['widget']['#description'] = t('Choose a layout to display the page as a whole. Choose "- None -" to keep the default layout setting.');
+      $field_widget_complete_form['widget']['#description'] = t('Choose a layout to display the page as a whole. Choose "- Default -" to keep the default layout setting.');
 
-      $noneOption = $this->t('Default');
+      $noneOption = $this->t('- Default -');
 
       if ($field_def->getTargetBundle() == 'stanford_news') {
         $noneOption = $this->t('News');

--- a/src/Hook/FormHooks.php
+++ b/src/Hook/FormHooks.php
@@ -129,4 +129,24 @@ class FormHooks {
     unset($form['vocabularies']['#header']['weight'], $form['actions']);
   }
 
+  /**
+   * Implements hook_field_widget_complete_WIDGET_TYPE_form_alter().
+   */
+  #[Hook('field_widget_complete_options_select_form_alter')]
+  public function fieldWidgetCompleteOptionsSelectFormAlter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
+    /** @var \Drupal\Core\Field\FieldItemListInterface $items */
+    $items = $context['items'];
+    $field_def = $items->getFieldDefinition();
+    if ($field_def->getName() == 'layout_selection') {
+      $field_widget_complete_form['widget']['#description'] = t('Choose a layout to display the page as a whole. Choose "- None -" to keep the default layout setting.');
+
+      $noneOption = $this->t('Default');
+
+      if ($field_def->getTargetBundle() == 'stanford_news') {
+        $noneOption = $this->t('News');
+      }
+      $field_widget_complete_form['widget']['#options']['_none'] = $noneOption;
+    }
+  }
+
 }

--- a/src/Hook/FormHooks.php
+++ b/src/Hook/FormHooks.php
@@ -144,6 +144,7 @@ class FormHooks {
 
       if ($field_def->getTargetBundle() == 'stanford_news') {
         $noneOption = $this->t('News');
+        $field_widget_complete_form['widget']['#title'] = t('Variant');
       }
       $field_widget_complete_form['widget']['#options']['_none'] = $noneOption;
     }

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -524,17 +524,6 @@ function stanford_profile_helper_entity_field_access($operation, FieldDefinition
 }
 
 /**
- * Implements hook_field_widget_complete_WIDGET_TYPE_form_alter().
- */
-function stanford_profile_helper_field_widget_complete_options_select_form_alter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
-  /** @var \Drupal\Core\Field\FieldStorageDefinitionInterface $field_def */
-  $field_def = $context['items']->getFieldDefinition();
-  if ($field_def->getName() == 'layout_selection') {
-    $field_widget_complete_form['widget']['#description'] = t('Choose a layout to display the page as a whole. Choose "- None -" to keep the default layout setting.');
-  }
-}
-
-/**
  * Implements hook_preprocess_toolbar().
  */
 function stanford_profile_helper_preprocess_toolbar(&$variables) {

--- a/tests/src/Kernel/Hook/FormHooksTest.php
+++ b/tests/src/Kernel/Hook/FormHooksTest.php
@@ -169,24 +169,21 @@ class FormHooksTest extends SuProfileHelperKernelTestBase {
   }
 
   /**
-   * Test the layout_selection field widget form alter.
+   * Test the layout_selection field widget form alter for stanford_news.
    */
   public function testLayoutSelectionFieldWidgetFormAlter() {
-    // Install node schema.
     $this->installEntitySchema('node');
     $this->installConfig(['node', 'field']);
     
-    // Create a content type for testing.
-    $node_type = $this->container->get('entity_type.manager')
+    $news_type = $this->container->get('entity_type.manager')
       ->getStorage('node_type')
       ->create([
-        'type' => 'stanford_page',
-        'name' => 'Basic Page',
+        'type' => 'stanford_news',
+        'name' => 'News',
       ]);
-    $node_type->save();
+    $news_type->save();
 
-    // Create the layout_selection field storage.
-    $field_storage = FieldStorageConfig::create([
+    $layout_field_storage = FieldStorageConfig::create([
       'field_name' => 'layout_selection',
       'entity_type' => 'node',
       'type' => 'list_string',
@@ -198,71 +195,26 @@ class FormHooksTest extends SuProfileHelperKernelTestBase {
         ],
       ],
     ]);
-    $field_storage->save();
+    $layout_field_storage->save();
 
-    // Create field instance for the page bundle.
     FieldConfig::create([
-      'field_storage' => $field_storage,
-      'bundle' => 'stanford_page',
-      'label' => 'Layout Selection',
-      'settings' => [],
-    ])->save();
-
-    // Create form display for the field.
-    $form_display = EntityFormDisplay::create([
-      'targetEntityType' => 'node',
-      'bundle' => 'stanford_page',
-      'mode' => 'default',
-      'status' => TRUE,
-    ]);
-    $form_display->setComponent('layout_selection', ['type' => 'options_select']);
-    $form_display->save();
-
-    // Create a node to test with.
-    $node = $this->container->get('entity_type.manager')
-      ->getStorage('node')
-      ->create([
-        'type' => 'stanford_page',
-        'title' => 'Test Page',
-      ]);
-    $node->save();
-
-    // Build the form.
-    $form = \Drupal::service('entity.form_builder')->getForm($node);
-
-    // Assert the default behavior for non-news content type.
-    $this->assertNotEmpty($form['layout_selection']['widget']['#description']);
-    $this->assertStringContainsString('Choose a layout to display the page', (string) $form['layout_selection']['widget']['#description']);
-    $this->assertEquals('Default', $form['layout_selection']['widget']['#options']['_none']);
-
-    // Test with stanford_news content type.
-    $news_type = $this->container->get('entity_type.manager')
-      ->getStorage('node_type')
-      ->create([
-        'type' => 'stanford_news',
-        'name' => 'News',
-      ]);
-    $news_type->save();
-
-    // Create field instance for stanford_news bundle.
-    FieldConfig::create([
-      'field_storage' => $field_storage,
+      'field_storage' => $layout_field_storage,
       'bundle' => 'stanford_news',
       'label' => 'Layout Selection',
       'settings' => [],
     ])->save();
 
-    // Create form display for stanford_news.
     $news_form_display = EntityFormDisplay::create([
       'targetEntityType' => 'node',
       'bundle' => 'stanford_news',
       'mode' => 'default',
       'status' => TRUE,
     ]);
-    $news_form_display->setComponent('layout_selection', ['type' => 'options_select']);
+    $news_form_display->setComponent('layout_selection', [
+      'type' => 'options_select'
+    ]);
     $news_form_display->save();
 
-    // Create a news node.
     $news_node = $this->container->get('entity_type.manager')
       ->getStorage('node')
       ->create([
@@ -271,11 +223,9 @@ class FormHooksTest extends SuProfileHelperKernelTestBase {
       ]);
     $news_node->save();
 
-    // Build the news form.
-    $news_form = \Drupal::service('entity.form_builder')->getForm($news_node);
+    $form = \Drupal::service('entity.form_builder')->getForm($news_node);
 
-    // Assert the stanford_news specific behavior.
-    $this->assertEquals('News', $news_form['layout_selection']['widget']['#options']['_none']);
-    $this->assertEquals('Variant', (string) $news_form['layout_selection']['widget']['#title']);
+    $this->assertEquals('News', $form['layout_selection']['widget']['#options']['_none']);
+    $this->assertEquals('Variant', (string) $form['layout_selection']['widget']['#title']);
   }
 }

--- a/tests/src/Kernel/Hook/FormHooksTest.php
+++ b/tests/src/Kernel/Hook/FormHooksTest.php
@@ -168,4 +168,114 @@ class FormHooksTest extends SuProfileHelperKernelTestBase {
     $this->assertArrayNotHasKey('foo', $form['vocabularies']);
   }
 
+  /**
+   * Test the layout_selection field widget form alter.
+   */
+  public function testLayoutSelectionFieldWidgetFormAlter() {
+    // Install node schema.
+    $this->installEntitySchema('node');
+    $this->installConfig(['node', 'field']);
+    
+    // Create a content type for testing.
+    $node_type = $this->container->get('entity_type.manager')
+      ->getStorage('node_type')
+      ->create([
+        'type' => 'stanford_page',
+        'name' => 'Basic Page',
+      ]);
+    $node_type->save();
+
+    // Create the layout_selection field storage.
+    $field_storage = FieldStorageConfig::create([
+      'field_name' => 'layout_selection',
+      'entity_type' => 'node',
+      'type' => 'list_string',
+      'cardinality' => 1,
+      'settings' => [
+        'allowed_values' => [
+          'layout_1' => 'Layout 1',
+          'layout_2' => 'Layout 2',
+        ],
+      ],
+    ]);
+    $field_storage->save();
+
+    // Create field instance for the page bundle.
+    FieldConfig::create([
+      'field_storage' => $field_storage,
+      'bundle' => 'stanford_page',
+      'label' => 'Layout Selection',
+      'settings' => [],
+    ])->save();
+
+    // Create form display for the field.
+    $form_display = EntityFormDisplay::create([
+      'targetEntityType' => 'node',
+      'bundle' => 'stanford_page',
+      'mode' => 'default',
+      'status' => TRUE,
+    ]);
+    $form_display->setComponent('layout_selection', ['type' => 'options_select']);
+    $form_display->save();
+
+    // Create a node to test with.
+    $node = $this->container->get('entity_type.manager')
+      ->getStorage('node')
+      ->create([
+        'type' => 'stanford_page',
+        'title' => 'Test Page',
+      ]);
+    $node->save();
+
+    // Build the form.
+    $form = \Drupal::service('entity.form_builder')->getForm($node);
+
+    // Assert the default behavior for non-news content type.
+    $this->assertNotEmpty($form['layout_selection']['widget']['#description']);
+    $this->assertStringContainsString('Choose a layout to display the page', (string) $form['layout_selection']['widget']['#description']);
+    $this->assertEquals('Default', $form['layout_selection']['widget']['#options']['_none']);
+
+    // Test with stanford_news content type.
+    $news_type = $this->container->get('entity_type.manager')
+      ->getStorage('node_type')
+      ->create([
+        'type' => 'stanford_news',
+        'name' => 'News',
+      ]);
+    $news_type->save();
+
+    // Create field instance for stanford_news bundle.
+    FieldConfig::create([
+      'field_storage' => $field_storage,
+      'bundle' => 'stanford_news',
+      'label' => 'Layout Selection',
+      'settings' => [],
+    ])->save();
+
+    // Create form display for stanford_news.
+    $news_form_display = EntityFormDisplay::create([
+      'targetEntityType' => 'node',
+      'bundle' => 'stanford_news',
+      'mode' => 'default',
+      'status' => TRUE,
+    ]);
+    $news_form_display->setComponent('layout_selection', ['type' => 'options_select']);
+    $news_form_display->save();
+
+    // Create a news node.
+    $news_node = $this->container->get('entity_type.manager')
+      ->getStorage('node')
+      ->create([
+        'type' => 'stanford_news',
+        'title' => 'Test News',
+      ]);
+    $news_node->save();
+
+    // Build the news form.
+    $news_form = \Drupal::service('entity.form_builder')->getForm($news_node);
+
+    // Assert the stanford_news specific behavior.
+    $this->assertEquals('News', $news_form['layout_selection']['widget']['#options']['_none']);
+    $this->assertEquals('Variant', (string) $news_form['layout_selection']['widget']['#title']);
+  }
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Rename _none option for News Spotlight variant layout selection

# Review By (Date)
- EOD Oct 8

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Checkout PR https://github.com/SU-SWS/stanford_profile/pull/991 in `stanford_profile`
3. Rebuild Cache and import config `drush cr ; drush ci`
4. Create a news item
5. Verify that the Variant select list at the top of News CT displays the options "News" and "Spotlights
6. Review code


# Associated Issues and/or People
- D8CORE-8227
- https://github.com/SU-SWS/stanford_profile/pull/991