### PR TITLE
Fix php 8.4 deprecation warnings

### DIFF
--- a/modules/jumpstart_ui/src/Plugin/TwigPlugin/JumpstartUITwig.php
+++ b/modules/jumpstart_ui/src/Plugin/TwigPlugin/JumpstartUITwig.php
@@ -27,7 +27,7 @@ class JumpstartUITwig extends AbstractExtension {
    * @param \Drupal\Core\Render\RendererInterface $renderer
    *   Renderer service.
    */
-  public function __construct(RendererInterface $renderer = NULL) {
+  public function __construct(RendererInterface|null $renderer = NULL) {
     $this->renderer = $renderer;
   }
 

--- a/modules/stanford_person/modules/stanford_person_importer/src/Cap.php
+++ b/modules/stanford_person/modules/stanford_person_importer/src/Cap.php
@@ -229,7 +229,7 @@ class Cap implements CapInterface {
    *
    * @throws \Exception
    */
-  protected function insertOrgData(array $org_data, TermInterface $parent = NULL): void {
+  protected function insertOrgData(array $org_data, TermInterface|null $parent = NULL): void {
     if (!isset($org_data['orgCodes'])) {
       return;
     }

--- a/src/Plugin/search_api/processor/CustomValue.php
+++ b/src/Plugin/search_api/processor/CustomValue.php
@@ -16,7 +16,7 @@ class CustomValue extends SearchApiCustomValue {
   /**
    * {@inheritdoc}
    */
-  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+  public function getPropertyDefinitions(DatasourceInterface|null $datasource = NULL) {
     $properties = [];
 
     if (!$datasource) {

--- a/stanford_profile_helper.module
+++ b/stanford_profile_helper.module
@@ -451,7 +451,7 @@ function stanford_profile_helper_help_section_info_alter(array &$info) {
 /**
  * Implements hook_entity_field_access().
  */
-function stanford_profile_helper_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface $items = NULL) {
+function stanford_profile_helper_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, FieldItemListInterface|null $items = NULL) {
   if (
     $operation != 'view' &&
     $field_definition->getName() == 'status' &&


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
This fixes the php 8.4 deprecation in [stanford_profile_helper.module#L454](https://github.com/SU-SWS/stanford_profile_helper/blob/10.x/stanford_profile_helper.module#L454) for RFC [https://wiki.php.net/rfc/deprecate-implicitly-nullable-types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

This is an easy fix.  I'm not sure about the coding style for this though. But I think if using > PHP v8.0 the recommended way is to use a union type instead of prefixing the type with a question mark.

`FieldItemListInterface|null $items = NULL`

# Urgency
Normal

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Run drush cr
3. Inspect terminal for deprecation warnings.
4. Deprecation warnings are gone for stanford_profile_helper

