### PR TITLE
Disable center overlay position option

### DIFF
--- a/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/HeroPatternBehavior.php
+++ b/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/HeroPatternBehavior.php
@@ -93,11 +93,12 @@ class HeroPatternBehavior extends ParagraphsBehaviorBase {
       '#options' => [
         'left' => $this->t('Left Card'),
         'right' => $this->t('Right Card'),
-        'center' => $this->t('Center Transparent Overlay'),
+        //'center' => $this->t('Center Transparent Overlay'),
       ],
     ];
     $form['overlay_color_wrapper'] = [
       '#type' => 'container',
+      '#access' => \Drupal::state()->get('allow_hero_pattern_overlay_color'),
       '#states' => [
         'visible' => [
           ':input[name*="[hero_pattern][overlay_position]"]' => ['value' => 'center'],
@@ -112,6 +113,7 @@ class HeroPatternBehavior extends ParagraphsBehaviorBase {
       '#suffix' => "<div class='color-field-widget-box-form' id='$id'></div>",
       '#maxlength' => 7,
       '#size' => 7,
+      '#access' => \Drupal::state()->get('allow_hero_pattern_overlay_color'),
       '#attached' => [
         'library' => ['color_field/color-field-widget-box'],
         'drupalSettings' => [

--- a/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/HeroPatternBehavior.php
+++ b/modules/jumpstart_ui/src/Plugin/paragraphs/Behavior/HeroPatternBehavior.php
@@ -96,9 +96,13 @@ class HeroPatternBehavior extends ParagraphsBehaviorBase {
         //'center' => $this->t('Center Transparent Overlay'),
       ],
     ];
+    $allowOverlayColor = (bool) \Drupal::state()->get('allow_hero_pattern_overlay_color');
+    if ($allowOverlayColor) {
+      $form['overlay_position']['#options']['center'] =  $this->t('Center Transparent Overlay');
+    }
     $form['overlay_color_wrapper'] = [
       '#type' => 'container',
-      '#access' => \Drupal::state()->get('allow_hero_pattern_overlay_color'),
+      '#access' => $allowOverlayColor,
       '#states' => [
         'visible' => [
           ':input[name*="[hero_pattern][overlay_position]"]' => ['value' => 'center'],
@@ -113,7 +117,7 @@ class HeroPatternBehavior extends ParagraphsBehaviorBase {
       '#suffix' => "<div class='color-field-widget-box-form' id='$id'></div>",
       '#maxlength' => 7,
       '#size' => 7,
-      '#access' => \Drupal::state()->get('allow_hero_pattern_overlay_color'),
+      '#access' => $allowOverlayColor,
       '#attached' => [
         'library' => ['color_field/color-field-widget-box'],
         'drupalSettings' => [

--- a/modules/jumpstart_ui/tests/src/Unit/Plugin/paragraphs/Behavior/HeroPatternBehaviorTest.php
+++ b/modules/jumpstart_ui/tests/src/Unit/Plugin/paragraphs/Behavior/HeroPatternBehaviorTest.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Form\FormState;
+use Drupal\Core\State\StateInterface;
 use Drupal\jumpstart_ui\Plugin\paragraphs\Behavior\HeroPatternBehavior;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\paragraphs\Entity\ParagraphsType;
@@ -28,10 +29,12 @@ class HeroPatternBehaviorTest extends UnitTestCase {
     parent::setUp();
 
     $field_manager = $this->createMock(EntityFieldManagerInterface::class);
+    $state = $this->createMock(StateInterface::class);
 
     $container = new ContainerBuilder();
     $container->set('entity_field.manager', $field_manager);
     $container->set('string_translation', $this->getStringTranslationStub());
+    $container->set('state', $state);
     \Drupal::setContainer($container);
   }
 


### PR DESCRIPTION
This pull request introduces a conditional feature flag for the hero pattern overlay color options in the `HeroPatternBehavior` plugin. The main change is to restrict the display of certain overlay color controls based on a Drupal state setting, allowing for easier enablement or disablement of this feature without code changes.

Feature flag for overlay color controls:

* The `'center'` overlay position option is commented out in the overlay position select field, removing it from user selection.
* The `overlay_color_wrapper` container and the overlay color input field now check the `allow_hero_pattern_overlay_color` Drupal state to determine if they should be accessible or visible in the form. [[1]](diffhunk://#diff-a85702a64cba1a8dce53bbb37544fecd39a28084f5c6a9306803aa62d38d655aL96-R101) [[2]](diffhunk://#diff-a85702a64cba1a8dce53bbb37544fecd39a28084f5c6a9306803aa62d38d655aR116)