### PR TITLE
D8CORE-7681 | keep line breaks in for pre/code blocks

### DIFF
--- a/modules/stanford_decoupled/src/Plugin/Filter/SuCleanHtml.php
+++ b/modules/stanford_decoupled/src/Plugin/Filter/SuCleanHtml.php
@@ -52,6 +52,18 @@ class SuCleanHtml extends FilterBase implements ContainerFactoryPluginInterface 
       return new FilterProcessResult($text);
     }
 
+    // Store pre/code blocks temporarily to preserve their whitespace.
+    $pre_blocks = [];
+    $text = preg_replace_callback(
+      '/<pre[^>]*>.*?<\/pre>/is',
+      function($matches) use (&$pre_blocks) {
+        $placeholder = '___PRE_BLOCK_' . count($pre_blocks) . '___';
+        $pre_blocks[$placeholder] = $matches[0];
+        return $placeholder;
+      },
+      $text
+    );
+
     // Remove line breaks.
     $text = preg_replace('/(\r\n)+|\r+|\n+|\t+/', ' ', $text);
     // Remove html comments.
@@ -62,6 +74,11 @@ class SuCleanHtml extends FilterBase implements ContainerFactoryPluginInterface 
     // Remove link attributes that result from the linkit module. They aren't
     // necessary: data-entity-type data-entity-uuid data-entity-substitution.
     $text = preg_replace('/ data-entity-(type|uuid|substitution)="[^"]*"/', '', $text);
+
+    // Restore pre/code blocks with their original whitespace.
+    foreach ($pre_blocks as $placeholder => $original) {
+      $text = str_replace($placeholder, $original, $text);
+    }
 
     $ns = $this->entityTypeManager->getStorage('node');
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- D8CORE-7681 | keep line breaks in for pre/code blocks

# Review By (Date)
- When possible

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Rebuild Cache and import config `drush cr ; drush ci`
3. Sync your local with the user guide
4. Navigate to `/build/create-and-edit-pages/text-editing-basics/create-links`
5. Verify that the code block includes line breaks:
<img width="1045" height="409" alt="image" src="https://github.com/user-attachments/assets/fb93b30d-f2dc-4fd7-b895-0001d83bd5f6" />

6. Review code


# Associated Issues and/or People
- D8CORE-7681