### PR TITLE
D8CORE-8885: Update CAP API url

### DIFF
--- a/modules/stanford_person/modules/stanford_person_importer/src/CapInterface.php
+++ b/modules/stanford_person/modules/stanford_person_importer/src/CapInterface.php
@@ -24,7 +24,7 @@ interface CapInterface {
   /**
    * The actual CAP API.
    */
-  const CAP_URL = 'https://cap.stanford.edu/cap-api/api/profiles/v1';
+  const CAP_URL = 'https://api.stanford.edu/profiles/v1';
 
   /**
    * Set the CAP Client ID.

--- a/modules/stanford_person/modules/stanford_person_importer/tests/src/Unit/CapTest.php
+++ b/modules/stanford_person/modules/stanford_person_importer/tests/src/Unit/CapTest.php
@@ -172,22 +172,22 @@ class CapTest extends UnitTestCase {
   public function testUrls() {
     $url = urldecode($this->service->getOrganizationUrl(['foo', 'bar'])
       ->toString());
-    $this->assertEquals('https://cap.stanford.edu/cap-api/api/profiles/v1?orgCodes=FOO,BAR', $url);
+    $this->assertEquals('https://api.stanford.edu/profiles/v1?orgCodes=FOO,BAR', $url);
 
     $url = urldecode($this->service->getOrganizationUrl(['foo', 'bar'], TRUE)
       ->toString());
-    $this->assertEquals('https://cap.stanford.edu/cap-api/api/profiles/v1?orgCodes=FOO,BAR&includeChildren=true', $url);
+    $this->assertEquals('https://api.stanford.edu/profiles/v1?orgCodes=FOO,BAR&includeChildren=true', $url);
 
     $url = urldecode($this->service->getWorkgroupUrl(['foo:bar_-baz'])
       ->toString());
-    $this->assertEquals('https://cap.stanford.edu/cap-api/api/profiles/v1?privGroups=FOO:BAR_-BAZ', $url);
+    $this->assertEquals('https://api.stanford.edu/profiles/v1?privGroups=FOO:BAR_-BAZ', $url);
 
     $url = urldecode($this->service->getSunetUrl(['foobarbaz'])->toString());
-    $this->assertEquals('https://cap.stanford.edu/cap-api/api/profiles/v1?uids=foobarbaz&ps=1', $url);
+    $this->assertEquals('https://api.stanford.edu/profiles/v1?uids=foobarbaz&ps=1', $url);
 
     $sunets = array_fill(0, 20, 'foo');
     $url = urldecode($this->service->getSunetUrl($sunets)->toString());
-    $this->assertEquals("https://cap.stanford.edu/cap-api/api/profiles/v1?uids=foo&ps=1", $url);
+    $this->assertEquals("https://api.stanford.edu/profiles/v1?uids=foo&ps=1", $url);
   }
 
   /**


### PR DESCRIPTION
This pull request updates the CAP API endpoint used throughout the `stanford_person_importer` module to reflect a new URL. The constant defining the API URL in `CapInterface.php` has been updated, and all related unit tests in `CapTest.php` have been modified to expect the new endpoint.

**API URL Update:**

* Updated the `CAP_URL` constant in `CapInterface.php` to use `https://api.stanford.edu/profiles/v1` instead of the old `https://cap.stanford.edu/cap-api/api/profiles/v1` endpoint.

**Tests Update:**

* Updated all relevant assertions in `CapTest.php` to match the new API URL, ensuring that tests validate against the updated endpoint.