### PR TITLE
D8CORE-8845: Allow reordering taxonomy terms when config readonly is enabled

### DIFF
--- a/src/Hook/ConfigReadonlyHooks.php
+++ b/src/Hook/ConfigReadonlyHooks.php
@@ -48,7 +48,7 @@ class ConfigReadonlyHooks {
     // don't alter the configuration, such as resetting the order of
     // taxonomy terms.
     $routes_to_config = [
-      'entity.taxonomy_vocabulary.reset_form' => ['taxonomy.vocabulary.*'],
+      'entity.taxonomy_vocabulary.overview_form' => ['taxonomy.vocabulary.*'],
       'entity.search_api_index.rebuild_tracker' => ['search_api.index.*'],
       'entity.search_api_index.clear' => ['search_api.index.*'],
       'entity.search_api_index.reindex' => ['search_api.index.*'],

--- a/tests/src/Unit/Hook/ConfigReadonlyHooksTest.php
+++ b/tests/src/Unit/Hook/ConfigReadonlyHooksTest.php
@@ -93,7 +93,7 @@ class ConfigReadonlyHooksTest extends UnitTestCase {
     $themeConfig = $this->createMock(ImmutableConfig::class);
     $themeConfig->method('get')->with('default')->willReturn('olivero');
     $this->configFactory->method('get')->with('system.theme')->willReturn($themeConfig);
-    $this->routeMatch->method('getRouteName')->willReturn('entity.taxonomy_vocabulary.reset_form');
+    $this->routeMatch->method('getRouteName')->willReturn('entity.taxonomy_vocabulary.overview_form');
 
     $patterns = $this->hooks->configReadonlyWhitelistPatterns();
     $this->assertSame(['olivero.settings', 'taxonomy.vocabulary.*'], $patterns);


### PR DESCRIPTION
This pull request updates the configuration whitelist patterns in `ConfigReadonlyHooks.php` to better reflect the routes that should be allowed to alter configuration. The main change is to replace the taxonomy vocabulary reset form route with the overview form route.

Configuration route updates:

* Replaced the `'entity.taxonomy_vocabulary.reset_form'` route with `'entity.taxonomy_vocabulary.overview_form'` in the `$routes_to_config` mapping to ensure the correct taxonomy vocabulary route is whitelisted for configuration changes.